### PR TITLE
feat: improve pandora deeplink import handling

### DIFF
--- a/src-electron/preload.ts
+++ b/src-electron/preload.ts
@@ -20,6 +20,9 @@ contextBridge.exposeInMainWorld('pxDeepLink', {
         // 移除旧监听器，确保只注册一次
         ipcRenderer.removeAllListeners('import-profile-from-deeplink');
         ipcRenderer.on('import-profile-from-deeplink', (_event, data) => callback(data));
+    },
+    notifyReady: () => {
+        ipcRenderer.send('deeplink-handler-ready');
     }
 });
 

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -20,8 +20,9 @@ declare module '@vue/runtime-core' {
 declare global {
     interface Window {
         pxOs: () => string;
-        pxDeepLink: {
-            onImportProfile: (callback: (data: { url: string; name?: string }) => void) => void;
+        pxDeepLink?: {
+            onImportProfile: (callback: (data: { rawUrl?: string; url?: string; name?: string } | string) => void) => void;
+            notifyReady?: () => void | Promise<void>;
         };
     }
 }


### PR DESCRIPTION
## Summary
- queue deeplink URLs until the renderer registers a ready handler and notify it via IPC
- normalize deeplink payloads in the renderer and trigger profile imports with success/error feedback
- update the profiles view to react to deeplink import completion events instead of raw URLs

## Testing
- npm run lint *(fails: existing lint errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68c968dd5de8832cbf4068dccccd0bc1