### PR TITLE
Add deep-link cancelation, release updates, and dashboard selector

### DIFF
--- a/src-electron/tray.ts
+++ b/src-electron/tray.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 
-import {app, BrowserWindow, ipcMain, Menu, nativeImage, Tray} from 'electron';
+import {app, BrowserWindow, ipcMain, Menu, nativeImage, Tray, shell} from 'electron';
 import path from "node:path";
 import {storeSet} from "./store";
 import {disableAutoLaunch, enableAutoLaunch} from "./launch";
@@ -154,6 +154,12 @@ trayMap.set('tray.direct', {
     click: (menuItem) => switchMode(menuItem, 'direct')
 });
 trayMap.set('tray.profiles', {id: 'tray.profiles', label: '订阅', submenu: []});
+trayMap.set('tray.dashboard', {
+    id: 'tray.dashboard',
+    label: 'Open Dashboard',
+    submenu: [],
+    enabled: false,
+});
 trayMap.set('tray.proxy', {
     id: 'tray.proxy',
     label: '系统代理',
@@ -178,6 +184,7 @@ const createTrayMenu = () => [
     trayMap.get('tray.direct'),
     {type: 'separator'},
     trayMap.get('tray.profiles'),
+    trayMap.get('tray.dashboard'),
     {type: 'separator'},
     trayMap.get('tray.proxy'),
     trayMap.get('tray.tun'),
@@ -244,6 +251,16 @@ function emitWindow(name: string, ...value: any[]) {
     }
 }
 
+const openDashboardFromTray = (url: string) => {
+    if (!url) {
+        return;
+    }
+
+    void shell.openExternal(url).catch((error) => {
+        console.error('Failed to open dashboard link from tray', error);
+    });
+};
+
 
 // 监听消息
 onWindow("translate", function (trayOptions) {
@@ -286,6 +303,26 @@ onWindow("profiles", function (profiles) {
         })
     }
     trayMap.get(key).submenu = pList
+    currentMenu = Menu.buildFromTemplate(createTrayMenu());
+    tray.setContextMenu(currentMenu);
+})
+
+onWindow("dashboards", function (dashboards) {
+    const key = 'tray.dashboard';
+    const items = Array.isArray(dashboards)
+        ? dashboards
+            .filter((dashboard) => dashboard && dashboard.name && dashboard.url)
+            .map((dashboard) => ({
+                id: `${key}.${dashboard.key ?? dashboard.name}`,
+                label: dashboard.name,
+                type: 'normal',
+                click: () => openDashboardFromTray(dashboard.url),
+            }))
+        : [];
+
+    const menuItem = trayMap.get(key);
+    menuItem.submenu = items;
+    menuItem.enabled = items.length > 0;
     currentMenu = Menu.buildFromTemplate(createTrayMenu());
     tray.setContextMenu(currentMenu);
 })

--- a/src/App.vue
+++ b/src/App.vue
@@ -193,7 +193,7 @@ watch(() => menuStore.background, (nextBackground) => {
 }
 
 .update-banner {
-  margin: 12px 24px 0 24px;
+  margin: 12px 0 0 22px;
   padding: 14px 16px 16px;
   border-radius: 12px;
   background: rgba(255, 255, 255, 0.08);
@@ -204,6 +204,9 @@ watch(() => menuStore.background, (nextBackground) => {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  width: 193px;
+  align-self: flex-start;
+  box-sizing: border-box;
 }
 
 .update-banner__content {
@@ -220,7 +223,8 @@ watch(() => menuStore.background, (nextBackground) => {
 }
 
 .update-banner__open {
-  align-self: flex-start;
+  align-self: stretch;
+  width: 100%;
 }
 
 .update-banner__dismiss {

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,6 +8,28 @@
         <div class="top-icon"></div>
         <span class="top-title-text">Prizrak-Box</span>
       </div>
+      <div v-if="showUpdateBanner" class="update-banner">
+        <div class="update-banner__header">
+          <span class="update-banner__title">{{ t('updates.banner.title') }}</span>
+          <el-button
+              class="update-banner__dismiss"
+              text
+              size="small"
+              @click="dismissUpdateNotification"
+          >
+            {{ t('updates.actions.dismiss') }}
+          </el-button>
+        </div>
+        <p class="update-banner__message">{{ updateBannerMessage }}</p>
+        <el-button
+            class="update-banner__open"
+            type="primary"
+            size="small"
+            @click="openLatestRelease"
+        >
+          {{ t('updates.actions.open') }}
+        </el-button>
+      </div>
       <MyEvent/>
       <MyNav/>
       <MyRule/>
@@ -20,6 +42,7 @@
       <router-view/>
       <MyDrop/>
     </div>
+    <DeepLinkImportOverlay/>
   </div>
 </template>
 
@@ -27,8 +50,42 @@
 <script setup lang="ts">
 import {useMenuStore} from "@/store/menuStore";
 import {preloadBackgroundImage} from "@/util/theme";
+import DeepLinkImportOverlay from "@/components/DeepLinkImportOverlay.vue";
+import {useUpdateStore} from "@/store/updateStore";
+import {storeToRefs} from "pinia";
+import {Browser} from "@/runtime";
+import {useI18n} from "vue-i18n";
 
 const menuStore = useMenuStore();
+const updateStore = useUpdateStore();
+const {t} = useI18n();
+
+const {hasVisibleUpdate, latestDisplayName, latestUrl} = storeToRefs(updateStore);
+
+const showUpdateBanner = computed(() => hasVisibleUpdate.value);
+const updateVersionLabel = computed(() => latestDisplayName.value || t('updates.banner.version-unknown'));
+const updateBannerMessage = computed(() => t('updates.banner.message', {version: updateVersionLabel.value}));
+
+const openExternalLink = (url: string) => {
+  if (!url) {
+    return;
+  }
+
+  try {
+    Browser.OpenURL(url);
+  } catch (error) {
+    window.open(url, '_blank');
+  }
+};
+
+const openLatestRelease = () => {
+  const url = latestUrl.value || 'https://github.com/legiz-ru/Prizrak-Box/releases/latest';
+  openExternalLink(url);
+};
+
+const dismissUpdateNotification = () => {
+  updateStore.dismissCurrentUpdate();
+};
 
 // 当前背景
 const currentBackground = ref("linear-gradient(to bottom, #434343, #000000)");
@@ -139,5 +196,51 @@ watch(() => menuStore.background, (nextBackground) => {
   text-align: center;
   line-height: 1.2;
   width: 100%;
+}
+
+.update-banner {
+  margin: 12px 24px 0 24px;
+  padding: 14px 16px 16px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  color: var(--text-color);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.update-banner__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.update-banner__title {
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.update-banner__message {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  opacity: 0.85;
+}
+
+.update-banner__open {
+  align-self: flex-start;
+}
+
+.update-banner__dismiss {
+  color: inherit;
+  opacity: 0.7;
+}
+
+.update-banner__dismiss:hover {
+  opacity: 1;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,18 +9,13 @@
         <span class="top-title-text">Prizrak-Box</span>
       </div>
       <div v-if="showUpdateBanner" class="update-banner">
-        <div class="update-banner__header">
-          <span class="update-banner__title">{{ t('updates.banner.title') }}</span>
-          <el-button
+        <div class="update-banner__content">
+          <span class="update-banner__message">{{ updateBannerMessage }}</span>
+          <icon-mdi-close-circle
               class="update-banner__dismiss"
-              text
-              size="small"
               @click="dismissUpdateNotification"
-          >
-            {{ t('updates.actions.dismiss') }}
-          </el-button>
+          />
         </div>
-        <p class="update-banner__message">{{ updateBannerMessage }}</p>
         <el-button
             class="update-banner__open"
             type="primary"
@@ -60,11 +55,10 @@ const menuStore = useMenuStore();
 const updateStore = useUpdateStore();
 const {t} = useI18n();
 
-const {hasVisibleUpdate, latestDisplayName, latestUrl} = storeToRefs(updateStore);
+const {hasVisibleUpdate, latestUrl} = storeToRefs(updateStore);
 
 const showUpdateBanner = computed(() => hasVisibleUpdate.value);
-const updateVersionLabel = computed(() => latestDisplayName.value || t('updates.banner.version-unknown'));
-const updateBannerMessage = computed(() => t('updates.banner.message', {version: updateVersionLabel.value}));
+const updateBannerMessage = computed(() => t('updates.banner.message'));
 
 const openExternalLink = (url: string) => {
   if (!url) {
@@ -212,20 +206,14 @@ watch(() => menuStore.background, (nextBackground) => {
   gap: 10px;
 }
 
-.update-banner__header {
+.update-banner__content {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   gap: 8px;
 }
 
-.update-banner__title {
-  font-size: 0.95rem;
-  font-weight: 600;
-}
-
 .update-banner__message {
-  margin: 0;
+  flex: 1;
   font-size: 0.9rem;
   line-height: 1.4;
   opacity: 0.85;
@@ -238,6 +226,10 @@ watch(() => menuStore.background, (nextBackground) => {
 .update-banner__dismiss {
   color: inherit;
   opacity: 0.7;
+  cursor: pointer;
+  font-size: 1.1rem;
+  flex-shrink: 0;
+  transition: opacity 0.2s ease;
 }
 
 .update-banner__dismiss:hover {

--- a/src/api/profiles/index.ts
+++ b/src/api/profiles/index.ts
@@ -1,8 +1,9 @@
+import {AxiosRequestConfig} from "axios";
 import {Profile} from "@/types/profile";
 
 // 添加配置从input
-const addProfileFromInput = (proxy: any) => async function (profile: Profile): Promise<Profile[]> {
-    return await proxy.$http.post('/profile', profile);
+const addProfileFromInput = (proxy: any) => async function (profile: Profile, config?: AxiosRequestConfig): Promise<Profile[]> {
+    return await proxy.$http.post('/profile', profile, config);
 }
 
 // 添加配置从文件

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -39,6 +39,7 @@ declare module 'vue' {
     IconMdiCancel: typeof import('~icons/mdi/cancel')['default']
     IconMdiCardMinusOutline: typeof import('~icons/mdi/card-minus-outline')['default']
     IconMdiClose: typeof import('~icons/mdi/close')['default']
+    IconMdiCloseCircle: typeof import('~icons/mdi/close-circle')['default']
     IconMdiCog: typeof import('~icons/mdi/cog')['default']
     IconMdiCogOutline: typeof import('~icons/mdi/cog-outline')['default']
     IconMdiContentPaste: typeof import('~icons/mdi/content-paste')['default']

--- a/src/components/DeepLinkImportOverlay.vue
+++ b/src/components/DeepLinkImportOverlay.vue
@@ -1,0 +1,118 @@
+<template>
+  <Teleport to="body">
+    <transition name="deeplink-import-fade">
+      <div v-if="isImporting" class="deeplink-import-overlay" role="dialog" aria-live="assertive">
+        <div class="deeplink-import-overlay__content">
+          <div class="deeplink-import-overlay__spinner" aria-hidden="true"></div>
+          <p class="deeplink-import-overlay__message">{{ message }}</p>
+          <p class="deeplink-import-overlay__hint">{{ cancelHint }}</p>
+          <el-button
+            class="deeplink-import-overlay__cancel"
+            type="danger"
+            plain
+            @click="deepLinkImportStore.cancelImport"
+          >
+            {{ cancelText }}
+          </el-button>
+        </div>
+      </div>
+    </transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import {computed, onBeforeUnmount, onMounted} from 'vue';
+import {storeToRefs} from 'pinia';
+import {useI18n} from 'vue-i18n';
+import {useDeepLinkImportStore} from '@/store/deepLinkStore';
+
+const deepLinkImportStore = useDeepLinkImportStore();
+const {isImporting, message, cancelLabel} = storeToRefs(deepLinkImportStore);
+const {t} = useI18n();
+
+const cancelText = computed(() => cancelLabel.value || t('profiles.deeplink.cancel-import'));
+const cancelHint = computed(() => t('profiles.deeplink.cancel-hint'));
+
+const handleKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape' && isImporting.value) {
+    event.preventDefault();
+    deepLinkImportStore.cancelImport();
+  }
+};
+
+onMounted(() => {
+  window.addEventListener('keydown', handleKeydown);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('keydown', handleKeydown);
+});
+</script>
+
+<style scoped>
+.deeplink-import-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background-color: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.deeplink-import-overlay__content {
+  width: min(420px, 100%);
+  border-radius: 18px;
+  background: rgba(16, 16, 16, 0.85);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.35);
+  padding: 36px 32px 28px;
+  text-align: center;
+  color: #fff;
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.deeplink-import-overlay__spinner {
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 24px auto;
+  border-radius: 50%;
+  border: 4px solid rgba(255, 255, 255, 0.25);
+  border-top-color: var(--el-color-primary, #409eff);
+  animation: deeplink-import-spin 1s linear infinite;
+}
+
+.deeplink-import-overlay__message {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0 0 12px 0;
+}
+
+.deeplink-import-overlay__hint {
+  font-size: 0.9rem;
+  opacity: 0.75;
+  margin: 0 0 20px 0;
+}
+
+.deeplink-import-overlay__cancel {
+  width: 100%;
+  font-weight: 600;
+}
+
+.deeplink-import-fade-enter-active,
+.deeplink-import-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.deeplink-import-fade-enter-from,
+.deeplink-import-fade-leave-to {
+  opacity: 0;
+}
+
+@keyframes deeplink-import-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/src/components/menu/Language.vue
+++ b/src/components/menu/Language.vue
@@ -55,6 +55,7 @@ const trayMenuId = [
   'tray.global',
   'tray.direct',
   'tray.profiles',
+  'tray.dashboard',
   'tray.proxy',
   'tray.tun',
   'tray.quit'

--- a/src/components/setting/MyConfig.vue
+++ b/src/components/setting/MyConfig.vue
@@ -3,7 +3,7 @@
 import MyPort from "@/components/setting/MyPort.vue";
 import MyBind from "@/components/setting/MyBind.vue";
 import MyTun from "@/components/setting/MyTun.vue";
-import {EditPen} from "@element-plus/icons-vue";
+import {ArrowDown, EditPen} from "@element-plus/icons-vue";
 import {useWebStore} from "@/store/webStore";
 import {useHomeStore} from "@/store/homeStore";
 import {copy} from "@/util/pLoad";
@@ -14,7 +14,9 @@ import {changeMenu} from "@/util/menu";
 import {useRouter} from "vue-router";
 import {pUpdateMihomo} from "@/util/mihomo";
 import {useMenuStore} from "@/store/menuStore";
-import {Events} from "@/runtime";
+import {Browser, Events} from "@/runtime";
+import {useUpdateStore} from "@/store/updateStore";
+import {storeToRefs} from "pinia";
 
 // 获取当前 Vue 实例的 proxy 对象 和 api
 const {proxy} = getCurrentInstance()!;
@@ -26,6 +28,122 @@ const homeStore = useHomeStore()
 const menuStore = useMenuStore()
 const settingStore = useSettingStore()
 const {t} = useI18n()
+const updateStore = useUpdateStore()
+
+const {checking: updateChecking, lastCheckStatus, lastError, latestDisplayName, updateAvailable} = storeToRefs(updateStore)
+const {customDashboards} = storeToRefs(webStore)
+
+const manualUpdateStatus = computed(() => {
+  if (updateChecking.value) {
+    return {type: 'info', text: t('updates.status.checking')};
+  }
+
+  if (updateAvailable.value) {
+    const label = latestDisplayName.value || t('updates.banner.version-unknown');
+    return {type: 'warning', text: t('updates.status.available', {version: label})};
+  }
+
+  if (lastCheckStatus.value === 'up-to-date') {
+    return {type: 'success', text: t('updates.status.up-to-date')};
+  }
+
+  if (lastCheckStatus.value === 'error') {
+    const errorKey = lastError.value ? 'updates.status.error-details' : 'updates.status.error';
+    return {type: 'danger', text: t(errorKey, {message: lastError.value ?? ''})};
+  }
+
+  return {type: '', text: ''};
+});
+
+interface DashboardOption {
+  key: string;
+  name: string;
+  url: string;
+  isCustom?: boolean;
+}
+
+const defaultDashboards: DashboardOption[] = [
+  {
+    key: 'metacubexd',
+    name: 'MetaCubeXD',
+    url: 'https://metacubex.github.io/metacubexd/#/setup?http=true&hostname=%host&port=%port&secret=%secret',
+  },
+  {
+    key: 'yacd',
+    name: 'Yacd',
+    url: 'https://yacd.metacubex.one/?hostname=%host&port=%port&secret=%secret',
+  },
+  {
+    key: 'zashboard',
+    name: 'Zashboard',
+    url: 'https://board.zash.run.place/#/setup?http=true&hostname=%host&port=%port&secret=%secret',
+  },
+];
+
+const customDashboardOptions = computed<DashboardOption[]>(() =>
+  customDashboards.value.map((entry, index) => ({
+    key: `custom-${index}`,
+    name: entry.name,
+    url: entry.url,
+    isCustom: true,
+  })),
+);
+
+const dashboardOptions = computed(() => [...defaultDashboards, ...customDashboardOptions.value]);
+
+const dashboardDialogVisible = ref(false);
+const newDashboard = reactive({name: '', url: ''});
+const dashboardFormError = ref('');
+
+const formatDashboardUrl = (template: string) => template
+    .replace(/%host/g, webStore.host)
+    .replace(/%port/g, webStore.port)
+    .replace(/%secret/g, webStore.secret);
+
+const openExternalLink = (url: string) => {
+  if (!url) {
+    return;
+  }
+
+  try {
+    Browser.OpenURL(url)
+  } catch (e) {
+    window.open(url, '_blank')
+  }
+};
+
+const openDashboard = (dashboard: DashboardOption) => {
+  const formattedUrl = formatDashboardUrl(dashboard.url);
+  openExternalLink(formattedUrl);
+};
+
+const handleDashboardCommand = (command: DashboardOption | 'manage') => {
+  if (typeof command === 'string') {
+    dashboardDialogVisible.value = true;
+    return;
+  }
+
+  openDashboard(command);
+};
+
+const addCustomDashboardEntry = () => {
+  const name = newDashboard.name.trim();
+  const url = newDashboard.url.trim();
+
+  if (!name || !url) {
+    dashboardFormError.value = t('setting.dashboard.error');
+    return;
+  }
+
+  dashboardFormError.value = '';
+  webStore.addCustomDashboard({name, url});
+  newDashboard.name = '';
+  newDashboard.url = '';
+};
+
+const removeCustomDashboardEntry = (index: number) => {
+  webStore.removeCustomDashboard(index);
+};
 
 // 使用路由
 const router = useRouter()
@@ -88,12 +206,25 @@ function pxConfigDir() {
   api.configDir().then(res => window["pxConfigDir"](res))
 }
 
-// 检查更新
-function checkUpdate() {
-  const url = "https://github.com/legiz-ru/Prizrak-Box/releases"
-  // @ts-ignore
-  window["pxOpen"](url)
+const releasesPageUrl = 'https://github.com/legiz-ru/Prizrak-Box/releases/latest'
+
+// 打开更新页面
+function openReleasesPage() {
+  openExternalLink(releasesPageUrl)
 }
+
+// 手动检查更新
+async function checkForUpdatesManually() {
+  await updateStore.checkForUpdates()
+}
+
+watch(dashboardDialogVisible, (visible) => {
+  if (!visible) {
+    dashboardFormError.value = '';
+    newDashboard.name = '';
+    newDashboard.url = '';
+  }
+});
 
 // 初始化HTTP客户端配置
 onMounted(async () => {
@@ -145,13 +276,36 @@ onMounted(async () => {
                 class="set-switch"
             />
           </li>
-          <li style="height: 30px">
+          <li class="api-row">
             <strong>Api :</strong>
-            {{ webStore.baseUrl }}
+            <span class="api-row__value">{{ webStore.baseUrl }}</span>
             <el-button
-                @click="copy(webStore.baseUrl,t)">
+                @click="copy(webStore.baseUrl,t)"
+                class="api-row__button">
               {{ $t('copy.title') }}
             </el-button>
+            <el-dropdown trigger="click" @command="handleDashboardCommand" class="api-row__dropdown">
+              <el-button class="api-row__button" type="primary" plain>
+                {{ t('setting.dashboard.open') }}
+                <el-icon class="api-row__icon">
+                  <ArrowDown/>
+                </el-icon>
+              </el-button>
+              <template #dropdown>
+                <el-dropdown-menu>
+                  <el-dropdown-item
+                      v-for="dashboard in dashboardOptions"
+                      :key="dashboard.key"
+                      :command="dashboard"
+                  >
+                    {{ dashboard.name }}
+                  </el-dropdown-item>
+                  <el-dropdown-item divided command="manage">
+                    {{ t('setting.dashboard.manage') }}
+                  </el-dropdown-item>
+                </el-dropdown-menu>
+              </template>
+            </el-dropdown>
           </li>
           <li style="height: 30px">
             <strong>Secret:</strong>
@@ -206,9 +360,21 @@ onMounted(async () => {
             <!--            <el-button>{{ $t('setting.px.export') }}</el-button>-->
             <!--            <el-button>{{ $t('setting.px.import') }}</el-button>-->
           </li>
-          <li style="height: 30px">
+          <li class="update-row">
             <strong>{{ $t('setting.px.update') }} :</strong>
-            <el-button @click="checkUpdate" style="margin-left: 10px">{{ $t('setting.px.check') }}</el-button>
+            <el-button @click="openReleasesPage" class="update-row__button">{{ t('updates.actions.open') }}</el-button>
+            <el-button
+                @click="checkForUpdatesManually"
+                :loading="updateChecking"
+                class="update-row__button"
+                type="primary"
+                plain
+            >
+              {{ t('updates.actions.check') }}
+            </el-button>
+            <span v-if="manualUpdateStatus.text" :class="['update-status', manualUpdateStatus.type && `update-status--${manualUpdateStatus.type}`]">
+              {{ manualUpdateStatus.text }}
+            </span>
           </li>
         </ul>
       </div>
@@ -216,6 +382,44 @@ onMounted(async () => {
   </el-row>
 
 
+  <el-dialog
+      v-model="dashboardDialogVisible"
+      :title="t('setting.dashboard.custom-title')"
+      width="520px"
+  >
+    <div class="dashboard-dialog">
+      <div class="dashboard-dialog__form">
+        <el-form label-position="top" class="dashboard-dialog__form-fields">
+          <el-form-item :label="t('setting.dashboard.name')">
+            <el-input v-model="newDashboard.name" placeholder="MetaCubeXD"/>
+          </el-form-item>
+          <el-form-item :label="t('setting.dashboard.url')">
+            <el-input v-model="newDashboard.url" placeholder="https://example.com"/>
+          </el-form-item>
+        </el-form>
+        <p class="dashboard-dialog__hint">{{ t('setting.dashboard.hint') }}</p>
+        <div class="dashboard-dialog__actions">
+          <el-button type="primary" @click="addCustomDashboardEntry">{{ t('setting.dashboard.add') }}</el-button>
+        </div>
+        <p v-if="dashboardFormError" class="dashboard-dialog__error">{{ dashboardFormError }}</p>
+      </div>
+      <el-divider/>
+      <div v-if="customDashboards.length === 0" class="dashboard-dialog__empty">
+        {{ t('setting.dashboard.empty') }}
+      </div>
+      <ul v-else class="dashboard-dialog__list">
+        <li v-for="(item, index) in customDashboards" :key="item.name + index" class="dashboard-dialog__item">
+          <div class="dashboard-dialog__item-info">
+            <span class="dashboard-dialog__item-name">{{ item.name }}</span>
+            <span class="dashboard-dialog__item-url">{{ item.url }}</span>
+          </div>
+          <el-button type="danger" link @click="removeCustomDashboardEntry(index)">
+            {{ t('setting.dashboard.remove') }}
+          </el-button>
+        </li>
+      </ul>
+    </div>
+  </el-dialog>
 </template>
 
 <style scoped>
@@ -244,6 +448,134 @@ onMounted(async () => {
 .info-list li {
   font-size: 18px;
   margin: 8px 0;
+}
+
+.api-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 30px;
+}
+
+.api-row strong {
+  margin-right: 6px;
+}
+
+.api-row__value {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.95rem;
+}
+
+.api-row__button {
+  margin-left: 10px;
+}
+
+.api-row__icon {
+  margin-left: 4px;
+  font-size: 0.85rem;
+}
+
+.update-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 30px;
+}
+
+.update-row strong {
+  margin-right: 6px;
+}
+
+.update-row__button {
+  margin-left: 10px;
+}
+
+.update-status {
+  font-size: 0.85rem;
+}
+
+.update-status--info {
+  color: #909399;
+}
+
+.update-status--success {
+  color: #67c23a;
+}
+
+.update-status--warning {
+  color: #e6a23c;
+}
+
+.update-status--danger {
+  color: #f56c6c;
+}
+
+.dashboard-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dashboard-dialog__form-fields {
+  display: grid;
+  gap: 12px;
+}
+
+.dashboard-dialog__actions {
+  margin-top: 4px;
+}
+
+.dashboard-dialog__hint {
+  font-size: 0.85rem;
+  opacity: 0.75;
+  margin: 0;
+}
+
+.dashboard-dialog__error {
+  color: #f56c6c;
+  font-size: 0.85rem;
+  margin: 6px 0 0;
+}
+
+.dashboard-dialog__empty {
+  text-align: center;
+  opacity: 0.7;
+  font-size: 0.9rem;
+}
+
+.dashboard-dialog__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.dashboard-dialog__item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.dashboard-dialog__item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-width: 75%;
+}
+
+.dashboard-dialog__item-name {
+  font-weight: 600;
+}
+
+.dashboard-dialog__item-url {
+  font-size: 0.85rem;
+  word-break: break-all;
+  opacity: 0.75;
 }
 
 .box1 {

--- a/src/components/setting/MyConfig.vue
+++ b/src/components/setting/MyConfig.vue
@@ -285,7 +285,7 @@ onMounted(async () => {
               {{ $t('copy.title') }}
             </el-button>
             <el-dropdown trigger="click" @command="handleDashboardCommand" class="api-row__dropdown">
-              <el-button class="api-row__button" type="primary" plain>
+              <el-button class="api-row__button">
                 {{ t('setting.dashboard.open') }}
                 <el-icon class="api-row__icon">
                   <ArrowDown/>
@@ -326,8 +326,14 @@ onMounted(async () => {
           margin-right: 0;">
     <el-col :span="24">
       <div class="box box2">
-        <div class="title">
-          Prizrak-Box
+        <div class="title title--status">
+          <span class="title__label">Prizrak-Box</span>
+          <span
+              v-if="manualUpdateStatus.text"
+              :class="['title__status', manualUpdateStatus.type && `title__status--${manualUpdateStatus.type}`]"
+          >
+            {{ manualUpdateStatus.text }}
+          </span>
         </div>
         <hr/>
         <ul class="info-list">
@@ -367,14 +373,9 @@ onMounted(async () => {
                 @click="checkForUpdatesManually"
                 :loading="updateChecking"
                 class="update-row__button"
-                type="primary"
-                plain
             >
               {{ t('updates.actions.check') }}
             </el-button>
-            <span v-if="manualUpdateStatus.text" :class="['update-status', manualUpdateStatus.type && `update-status--${manualUpdateStatus.type}`]">
-              {{ manualUpdateStatus.text }}
-            </span>
           </li>
         </ul>
       </div>
@@ -463,8 +464,8 @@ onMounted(async () => {
 }
 
 .api-row__value {
-  font-family: 'JetBrains Mono', 'Fira Code', monospace;
-  font-size: 0.95rem;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .api-row__button {
@@ -492,23 +493,29 @@ onMounted(async () => {
   margin-left: 10px;
 }
 
-.update-status {
+.title--status {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title__status {
   font-size: 0.85rem;
 }
 
-.update-status--info {
+.title__status--info {
   color: #909399;
 }
 
-.update-status--success {
+.title__status--success {
   color: #67c23a;
 }
 
-.update-status--warning {
+.title__status--warning {
   color: #e6a23c;
 }
 
-.update-status--danger {
+.title__status--danger {
   color: #f56c6c;
 }
 

--- a/src/components/setting/MyConfig.vue
+++ b/src/components/setting/MyConfig.vue
@@ -17,6 +17,8 @@ import {useMenuStore} from "@/store/menuStore";
 import {Browser, Events} from "@/runtime";
 import {useUpdateStore} from "@/store/updateStore";
 import {storeToRefs} from "pinia";
+import type {DashboardOption} from "@/util/dashboard";
+import {formatDashboardUrl as buildDashboardUrl, resolveDashboardOptions} from "@/util/dashboard";
 
 // 获取当前 Vue 实例的 proxy 对象 和 api
 const {proxy} = getCurrentInstance()!;
@@ -55,50 +57,13 @@ const manualUpdateStatus = computed(() => {
   return {type: '', text: ''};
 });
 
-interface DashboardOption {
-  key: string;
-  name: string;
-  url: string;
-  isCustom?: boolean;
-}
-
-const defaultDashboards: DashboardOption[] = [
-  {
-    key: 'metacubexd',
-    name: 'MetaCubeXD',
-    url: 'https://metacubex.github.io/metacubexd/#/setup?http=true&hostname=%host&port=%port&secret=%secret',
-  },
-  {
-    key: 'yacd',
-    name: 'Yacd',
-    url: 'https://yacd.metacubex.one/?hostname=%host&port=%port&secret=%secret',
-  },
-  {
-    key: 'zashboard',
-    name: 'Zashboard',
-    url: 'https://board.zash.run.place/#/setup?http=true&hostname=%host&port=%port&secret=%secret',
-  },
-];
-
-const customDashboardOptions = computed<DashboardOption[]>(() =>
-  customDashboards.value.map((entry, index) => ({
-    key: `custom-${index}`,
-    name: entry.name,
-    url: entry.url,
-    isCustom: true,
-  })),
+const dashboardOptions = computed<DashboardOption[]>(() =>
+  resolveDashboardOptions(customDashboards.value),
 );
-
-const dashboardOptions = computed(() => [...defaultDashboards, ...customDashboardOptions.value]);
 
 const dashboardDialogVisible = ref(false);
 const newDashboard = reactive({name: '', url: ''});
 const dashboardFormError = ref('');
-
-const formatDashboardUrl = (template: string) => template
-    .replace(/%host/g, webStore.host)
-    .replace(/%port/g, webStore.port)
-    .replace(/%secret/g, webStore.secret);
 
 const openExternalLink = (url: string) => {
   if (!url) {
@@ -113,7 +78,11 @@ const openExternalLink = (url: string) => {
 };
 
 const openDashboard = (dashboard: DashboardOption) => {
-  const formattedUrl = formatDashboardUrl(dashboard.url);
+  const formattedUrl = buildDashboardUrl(dashboard.url, {
+    host: webStore.host,
+    port: webStore.port,
+    secret: webStore.secret,
+  });
   openExternalLink(formattedUrl);
 };
 
@@ -277,35 +246,37 @@ onMounted(async () => {
             />
           </li>
           <li class="api-row">
-            <strong>Api :</strong>
-            <span class="api-row__value">{{ webStore.baseUrl }}</span>
-            <el-button
-                @click="copy(webStore.baseUrl,t)"
-                class="api-row__button">
-              {{ $t('copy.title') }}
-            </el-button>
-            <el-dropdown trigger="click" @command="handleDashboardCommand" class="api-row__dropdown">
-              <el-button class="api-row__button">
-                {{ t('setting.dashboard.open') }}
-                <el-icon class="api-row__icon">
-                  <ArrowDown/>
-                </el-icon>
+            <div class="api-row__info">
+              <strong>Api :</strong>
+              <span class="api-row__value">{{ webStore.baseUrl }}</span>
+            </div>
+            <div class="api-row__actions">
+              <el-button @click="copy(webStore.baseUrl,t)">
+                {{ $t('copy.title') }}
               </el-button>
-              <template #dropdown>
-                <el-dropdown-menu>
-                  <el-dropdown-item
-                      v-for="dashboard in dashboardOptions"
-                      :key="dashboard.key"
-                      :command="dashboard"
-                  >
-                    {{ dashboard.name }}
-                  </el-dropdown-item>
-                  <el-dropdown-item divided command="manage">
-                    {{ t('setting.dashboard.manage') }}
-                  </el-dropdown-item>
-                </el-dropdown-menu>
-              </template>
-            </el-dropdown>
+              <el-dropdown trigger="click" @command="handleDashboardCommand" class="api-row__dropdown">
+                <el-button>
+                  {{ t('setting.dashboard.open') }}
+                  <el-icon class="api-row__icon">
+                    <ArrowDown/>
+                  </el-icon>
+                </el-button>
+                <template #dropdown>
+                  <el-dropdown-menu>
+                    <el-dropdown-item
+                        v-for="dashboard in dashboardOptions"
+                        :key="dashboard.key"
+                        :command="dashboard"
+                    >
+                      {{ dashboard.name }}
+                    </el-dropdown-item>
+                    <el-dropdown-item divided command="manage">
+                      {{ t('setting.dashboard.manage') }}
+                    </el-dropdown-item>
+                  </el-dropdown-menu>
+                </template>
+              </el-dropdown>
+            </div>
           </li>
           <li style="height: 30px">
             <strong>Secret:</strong>
@@ -455,21 +426,30 @@ onMounted(async () => {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 12px;
   min-height: 30px;
 }
 
-.api-row strong {
-  margin-right: 6px;
+.api-row__info {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
 .api-row__value {
-  flex: 1 1 auto;
-  min-width: 0;
+  word-break: break-all;
 }
 
-.api-row__button {
-  margin-left: 10px;
+.api-row__actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.api-row__dropdown {
+  display: inline-flex;
 }
 
 .api-row__icon {
@@ -490,7 +470,7 @@ onMounted(async () => {
 }
 
 .update-row__button {
-  margin-left: 10px;
+  margin-left: 0;
 }
 
 .title--status {

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -132,7 +132,7 @@ setting:
 updates:
   banner:
     title: Update available
-    message: A new version {version} is available.
+    message: A new version is available.
     version-unknown: the latest release
   actions:
     open: View release

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -132,7 +132,7 @@ setting:
 updates:
   banner:
     title: Update available
-    message: A new version {{ version }} is available.
+    message: A new version {version} is available.
     version-unknown: the latest release
   actions:
     open: View release
@@ -140,13 +140,13 @@ updates:
     dismiss: Dismiss
   notification:
     title: New release available
-    message: Version {{ version }} is now available.
+    message: Version {version} is now available.
   status:
     checking: Checking for updates...
-    available: Version {{ version }} is available
+    available: Version {version} is available
     up-to-date: You already have the latest version
     error: Failed to check for updates
-    error-details: Failed to check for updates: {{ message }}
+    error-details: "Failed to check for updates: {message}"
 
 proxies:
   title: Proxies

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -117,6 +117,37 @@ setting:
     update: Update
     check: Check
 
+  dashboard:
+    open: Open dashboard
+    manage: Manage dashboards
+    custom-title: Custom dashboards
+    name: Name
+    url: URL
+    hint: You can use %host, %port and %secret in the URL.
+    add: Add
+    remove: Remove
+    empty: No custom dashboards yet
+    error: Please provide both a name and a URL
+
+updates:
+  banner:
+    title: Update available
+    message: A new version {{ version }} is available.
+    version-unknown: the latest release
+  actions:
+    open: View release
+    check: Check updates
+    dismiss: Dismiss
+  notification:
+    title: New release available
+    message: Version {{ version }} is now available.
+  status:
+    checking: Checking for updates...
+    available: Version {{ version }} is available
+    up-to-date: You already have the latest version
+    error: Failed to check for updates
+    error-details: Failed to check for updates: {{ message }}
+
 proxies:
   title: Proxies
   test: Latency Test
@@ -164,6 +195,9 @@ profiles:
     import-failed: Failed to import profile
     invalid-url: Invalid profile URL
     invalid-url-format: Invalid URL format, must be HTTP or HTTPS
+    cancel-import: Cancel import
+    cancel-hint: Press Esc to cancel
+    import-cancelled: Profile import cancelled
 
 rule:
   title: Rule

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -270,6 +270,7 @@ tray:
   global: Global
   direct: Direct
   profiles: Profiles
+  dashboard: Open dashboard
   proxy: Proxy
   tun: TUN
   quit: Quit

--- a/src/locales/ru.yaml
+++ b/src/locales/ru.yaml
@@ -132,7 +132,7 @@ setting:
 updates:
   banner:
     title: Доступно обновление
-    message: Доступна новая версия {version}.
+    message: Доступная новая версия
     version-unknown: новый релиз
   actions:
     open: Открыть релиз

--- a/src/locales/ru.yaml
+++ b/src/locales/ru.yaml
@@ -117,6 +117,37 @@ setting:
     update: Обновить
     check: Проверить
 
+  dashboard:
+    open: Открыть панель
+    manage: Управление панелями
+    custom-title: Пользовательские панели
+    name: Название
+    url: Ссылка
+    hint: В ссылке можно использовать %host, %port и %secret
+    add: Добавить
+    remove: Удалить
+    empty: Пока нет пользовательских панелей
+    error: Укажите название и ссылку
+
+updates:
+  banner:
+    title: Доступно обновление
+    message: Доступна новая версия {{ version }}.
+    version-unknown: новый релиз
+  actions:
+    open: Открыть релиз
+    check: Проверить обновления
+    dismiss: Скрыть
+  notification:
+    title: Доступна новая версия
+    message: Доступна версия {{ version }}.
+  status:
+    checking: Проверка обновлений...
+    available: Доступна версия {{ version }}
+    up-to-date: У вас установлена актуальная версия
+    error: Не удалось проверить обновления
+    error-details: Не удалось проверить обновления: {{ message }}
+
 proxies:
   title: Прокси
   test: Тест задержки
@@ -164,6 +195,9 @@ profiles:
     import-failed: Не удалось импортировать профиль
     invalid-url: Неверный URL профиля
     invalid-url-format: Неверный формат URL, должен быть HTTP или HTTPS
+    cancel-import: Отменить импорт
+    cancel-hint: Нажмите Esc, чтобы отменить
+    import-cancelled: Импорт профиля отменён
 
 rule:
   title: Правило

--- a/src/locales/ru.yaml
+++ b/src/locales/ru.yaml
@@ -132,7 +132,7 @@ setting:
 updates:
   banner:
     title: Доступно обновление
-    message: Доступна новая версия {{ version }}.
+    message: Доступна новая версия {version}.
     version-unknown: новый релиз
   actions:
     open: Открыть релиз
@@ -140,13 +140,13 @@ updates:
     dismiss: Скрыть
   notification:
     title: Доступна новая версия
-    message: Доступна версия {{ version }}.
+    message: Доступна версия {version}.
   status:
     checking: Проверка обновлений...
-    available: Доступна версия {{ version }}
+    available: Доступна версия {version}
     up-to-date: У вас установлена актуальная версия
     error: Не удалось проверить обновления
-    error-details: Не удалось проверить обновления: {{ message }}
+    error-details: "Не удалось проверить обновления: {message}"
 
 proxies:
   title: Прокси

--- a/src/locales/ru.yaml
+++ b/src/locales/ru.yaml
@@ -270,6 +270,7 @@ tray:
   global: Глобальный
   direct: Прямой
   profiles: Профили
+  dashboard: Открыть панель
   proxy: Прокси
   tun: TUN
   quit: Выйти

--- a/src/locales/zh.yaml
+++ b/src/locales/zh.yaml
@@ -132,7 +132,7 @@ setting:
 updates:
   banner:
     title: 发现新版本
-    message: 发现新版本 {{ version }}。
+    message: 发现新版本 {version}。
     version-unknown: 最新发布
   actions:
     open: 查看发布
@@ -140,13 +140,13 @@ updates:
     dismiss: 忽略
   notification:
     title: 有新版本可用
-    message: 版本 {{ version }} 已发布。
+    message: 版本 {version} 已发布。
   status:
     checking: 正在检查更新...
-    available: 检测到新版本 {{ version }}
+    available: 检测到新版本 {version}
     up-to-date: 当前已是最新版本
     error: 检查更新失败
-    error-details: 检查更新失败：{{ message }}
+    error-details: "检查更新失败：{message}"
 
 proxies:
   title: 代理

--- a/src/locales/zh.yaml
+++ b/src/locales/zh.yaml
@@ -132,7 +132,7 @@ setting:
 updates:
   banner:
     title: 发现新版本
-    message: 发现新版本 {version}。
+    message: 有新版本可用
     version-unknown: 最新发布
   actions:
     open: 查看发布

--- a/src/locales/zh.yaml
+++ b/src/locales/zh.yaml
@@ -117,6 +117,37 @@ setting:
     update: 软件更新
     check: 检查
 
+  dashboard:
+    open: 打开面板
+    manage: 管理面板
+    custom-title: 自定义面板
+    name: 名称
+    url: 链接
+    hint: 链接中可使用 %host、%port、%secret
+    add: 添加
+    remove: 删除
+    empty: 暂无自定义面板
+    error: 请输入名称和链接
+
+updates:
+  banner:
+    title: 发现新版本
+    message: 发现新版本 {{ version }}。
+    version-unknown: 最新发布
+  actions:
+    open: 查看发布
+    check: 检查更新
+    dismiss: 忽略
+  notification:
+    title: 有新版本可用
+    message: 版本 {{ version }} 已发布。
+  status:
+    checking: 正在检查更新...
+    available: 检测到新版本 {{ version }}
+    up-to-date: 当前已是最新版本
+    error: 检查更新失败
+    error-details: 检查更新失败：{{ message }}
+
 proxies:
   title: 代理
   test: 测试延迟
@@ -164,6 +195,9 @@ profiles:
     import-failed: 配置导入失败
     invalid-url: 无效的配置链接
     invalid-url-format: 配置链接格式错误，必须是 HTTP 或 HTTPS
+    cancel-import: 取消导入
+    cancel-hint: 按 Esc 键取消
+    import-cancelled: 配置导入已取消
 
 rule:
   title: 规则

--- a/src/locales/zh.yaml
+++ b/src/locales/zh.yaml
@@ -270,6 +270,7 @@ tray:
   global: 全局
   direct: 直连
   profiles: 订阅
+  dashboard: 打开面板
   proxy: 系统代理
   tun: Tun模式
   quit: 退出

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,6 @@ import {pError, pSuccess, pWarning} from "@/util/pLoad";
 import {isHttpOrHttps} from "@/util/format";
 import {useDeepLinkImportStore} from "@/store/deepLinkStore";
 import {useUpdateStore} from "@/store/updateStore";
-import {ElNotification} from "element-plus";
 import {Browser} from "@/runtime";
 
 const app = createApp(App);
@@ -292,20 +291,55 @@ function setupUpdateChecker() {
         }
 
         const label = updateStore.latestDisplayName || translate('updates.banner.version-unknown');
+        const title = translate('updates.notification.title');
+        const message = translate('updates.notification.message', {version: label});
 
-        ElNotification({
-            title: translate('updates.notification.title'),
-            message: translate('updates.notification.message', {version: label}),
-            type: 'info',
-            duration: 10000,
-            onClick: () => {
-                if (updateStore.latestUrl) {
-                    openExternalLink(updateStore.latestUrl);
+        const notify = async () => {
+            const NotificationCtor = window.Notification;
+
+            if (typeof NotificationCtor !== 'function') {
+                updateStore.markNotified();
+                return;
+            }
+
+            const showNotification = () => {
+                try {
+                    const notification = new NotificationCtor(title, {body: message});
+                    notification.onclick = () => {
+                        if (typeof window.focus === 'function') {
+                            window.focus();
+                        }
+
+                        if (updateStore.latestUrl) {
+                            openExternalLink(updateStore.latestUrl);
+                        }
+                    };
+                } catch (error) {
+                    console.error('Failed to display update notification', error);
                 }
-            },
-        });
+            };
 
-        updateStore.markNotified();
+            try {
+                let permission = NotificationCtor.permission;
+
+                if (permission === 'default' && typeof NotificationCtor.requestPermission === 'function') {
+                    try {
+                        permission = await NotificationCtor.requestPermission();
+                    } catch (error) {
+                        console.error('Failed to request notification permission', error);
+                        permission = 'denied';
+                    }
+                }
+
+                if (permission === 'granted') {
+                    showNotification();
+                }
+            } finally {
+                updateStore.markNotified();
+            }
+        };
+
+        void notify();
     }, {immediate: false});
 
     const performCheck = async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import {createApp} from "vue";
+import {createApp, watch} from "vue";
 import App from "./App.vue";
 import router from "@/router";
 import {createPinia} from "pinia";
@@ -19,8 +19,12 @@ import {memoryCache} from "@/types/persist"
 import {detectLanguage} from "@/util/menu";
 import createApi from "@/api";
 import {Profile} from "@/types/profile";
-import {pError, pLoad, pSuccess} from "@/util/pLoad";
+import {pError, pSuccess, pWarning} from "@/util/pLoad";
 import {isHttpOrHttps} from "@/util/format";
+import {useDeepLinkImportStore} from "@/store/deepLinkStore";
+import {useUpdateStore} from "@/store/updateStore";
+import {ElNotification} from "element-plus";
+import {Browser} from "@/runtime";
 
 const app = createApp(App);
 const lang = detectLanguage();
@@ -28,6 +32,25 @@ const DEEP_LINK_IMPORTED_EVENT = 'deeplink-profile-imported';
 const DEEP_LINK_HOST = 'install-config';
 const KNOWN_DEEP_LINK_EXTRA_KEYS = new Set(['name']);
 let deepLinkHandlerRegistered = false;
+let updateCheckerRegistered = false;
+const UPDATE_CHECK_INTERVAL = 6 * 60 * 60 * 1000;
+
+function isCanceledError(error: any) {
+    if (!error || typeof error !== 'object') {
+        return false;
+    }
+
+    const code = (error as any).code;
+    const name = (error as any).name;
+    const message = typeof (error as any).message === 'string' ? (error as any).message.toLowerCase() : '';
+
+    return code === 'ERR_CANCELED'
+        || name === 'CanceledError'
+        || (error as any).__CANCEL__ === true
+        || message === 'canceled'
+        || message === 'cancelled'
+        || message === 'aborted';
+}
 
 async function bootstrap() {
     // 加载缓存数据
@@ -86,6 +109,7 @@ async function bootstrap() {
     );
 
     setupDeepLinkHandler();
+    setupUpdateChecker();
 
     // 激活menu
     const menuStore = useMenuStore();
@@ -144,6 +168,8 @@ function setupDeepLinkHandler() {
         }
     };
 
+    const deepLinkImportStore = useDeepLinkImportStore();
+
     const importProfileFromDeepLink = async (payload: DeepLinkPayload) => {
         const normalized = normalizeDeepLinkPayload(payload);
         const parsed = normalized.rawUrl ? parseDeepLinkUrl(normalized.rawUrl) : null;
@@ -166,21 +192,48 @@ function setupDeepLinkHandler() {
             profile.title = profileName;
         }
 
+        const controller = new AbortController();
+        let cancelledByUser = false;
+        let overlayActive = false;
+
         try {
-            await pLoad(translate('profiles.deeplink.importing'), async () => {
-                const result = await api.addProfileFromInput(profile);
-                if (Array.isArray(result) && result.length > 0) {
-                    window.dispatchEvent(new CustomEvent(DEEP_LINK_IMPORTED_EVENT, {
-                        detail: {profiles: result}
-                    }));
-                }
+            deepLinkImportStore.startImport({
+                message: translate('profiles.deeplink.importing'),
+                cancelLabel: translate('profiles.deeplink.cancel-import'),
+                onCancel: () => {
+                    if (!controller.signal.aborted) {
+                        cancelledByUser = true;
+                        controller.abort();
+                    }
+                },
             });
+            overlayActive = true;
+
+            const result = await api.addProfileFromInput(profile, {signal: controller.signal});
+
+            if (controller.signal.aborted || cancelledByUser) {
+                pWarning(translate('profiles.deeplink.import-cancelled'));
+                return;
+            }
+
+            if (Array.isArray(result) && result.length > 0) {
+                window.dispatchEvent(new CustomEvent(DEEP_LINK_IMPORTED_EVENT, {
+                    detail: {profiles: result}
+                }));
+            }
+
             pSuccess(translate('profiles.deeplink.import-success'));
         } catch (error: any) {
-            if (error && typeof error === 'object' && 'message' in error && error.message) {
+            if (cancelledByUser || isCanceledError(error)) {
+                pWarning(translate('profiles.deeplink.import-cancelled'));
+            } else if (error && typeof error === 'object' && 'message' in error && error.message) {
                 pError(error.message);
             } else {
                 pError(translate('profiles.deeplink.import-failed'));
+            }
+        } finally {
+            if (overlayActive) {
+                deepLinkImportStore.finishImport();
             }
         }
     };
@@ -200,6 +253,70 @@ function setupDeepLinkHandler() {
     ensureDeepLinkReady();
 
     deepLinkHandlerRegistered = true;
+}
+
+function setupUpdateChecker() {
+    if (updateCheckerRegistered) {
+        return;
+    }
+
+    updateCheckerRegistered = true;
+
+    const updateStore = useUpdateStore();
+    const globalProperties: any = app.config.globalProperties;
+    const translate = (key: string, values?: Record<string, any>) => {
+        try {
+            return typeof globalProperties.$t === 'function'
+                ? globalProperties.$t(key, values)
+                : key;
+        } catch {
+            return key;
+        }
+    };
+
+    const openExternalLink = (url: string) => {
+        if (!url) {
+            return;
+        }
+
+        try {
+            Browser.OpenURL(url);
+        } catch (error) {
+            window.open(url, '_blank');
+        }
+    };
+
+    watch(() => updateStore.shouldNotify, (shouldNotify) => {
+        if (!shouldNotify) {
+            return;
+        }
+
+        const label = updateStore.latestDisplayName || translate('updates.banner.version-unknown');
+
+        ElNotification({
+            title: translate('updates.notification.title'),
+            message: translate('updates.notification.message', {version: label}),
+            type: 'info',
+            duration: 10000,
+            onClick: () => {
+                if (updateStore.latestUrl) {
+                    openExternalLink(updateStore.latestUrl);
+                }
+            },
+        });
+
+        updateStore.markNotified();
+    }, {immediate: false});
+
+    const performCheck = async () => {
+        await updateStore.checkForUpdates();
+    };
+
+    void performCheck();
+
+    window.setInterval(() => {
+        void performCheck();
+    }, UPDATE_CHECK_INTERVAL);
 }
 
 function normalizeDeepLinkPayload(payload: DeepLinkPayload): { rawUrl?: string; directUrl?: string; name?: string } {

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,8 @@ import {pError, pSuccess, pWarning} from "@/util/pLoad";
 import {isHttpOrHttps} from "@/util/format";
 import {useDeepLinkImportStore} from "@/store/deepLinkStore";
 import {useUpdateStore} from "@/store/updateStore";
-import {Browser} from "@/runtime";
+import {Browser, Events} from "@/runtime";
+import {createDashboardLinks} from "@/util/dashboard";
 
 const app = createApp(App);
 const lang = detectLanguage();
@@ -100,6 +101,26 @@ async function bootstrap() {
     if (secret) {
         webStore.setSecret(secret);
     }
+
+    const emitDashboardLinks = () => {
+        const dashboards = createDashboardLinks(webStore.customDashboards, {
+            host: webStore.host,
+            port: webStore.port,
+            secret: webStore.secret,
+        });
+
+        if ((window as any)?.pxTray?.emit) {
+            Events.Emit({name: "dashboards", data: dashboards});
+        }
+    };
+
+    watch(() => [webStore.host, webStore.port, webStore.secret], () => {
+        emitDashboardLinks();
+    }, {immediate: true});
+
+    watch(() => webStore.customDashboards, () => {
+        emitDashboardLinks();
+    }, {deep: true});
 
     // 注册 Axios 实例到全局
     app.config.globalProperties.$http = new AxiosRequest(

--- a/src/store/deepLinkStore.ts
+++ b/src/store/deepLinkStore.ts
@@ -1,0 +1,47 @@
+import {defineStore} from 'pinia';
+
+interface DeepLinkImportState {
+    isImporting: boolean;
+    message: string;
+    cancelLabel: string;
+    cancelHandler: (() => void) | null;
+}
+
+interface StartImportPayload {
+    message: string;
+    cancelLabel?: string;
+    onCancel?: () => void;
+}
+
+export const useDeepLinkImportStore = defineStore('deepLinkImport', {
+    state: (): DeepLinkImportState => ({
+        isImporting: false,
+        message: '',
+        cancelLabel: '',
+        cancelHandler: null,
+    }),
+    actions: {
+        startImport(payload: StartImportPayload) {
+            this.isImporting = true;
+            this.message = payload.message;
+            this.cancelLabel = payload.cancelLabel ?? '';
+            this.cancelHandler = payload.onCancel ?? null;
+        },
+        finishImport() {
+            this.isImporting = false;
+            this.message = '';
+            this.cancelLabel = '';
+            this.cancelHandler = null;
+        },
+        cancelImport() {
+            if (!this.isImporting) {
+                return;
+            }
+            const handler = this.cancelHandler;
+            this.finishImport();
+            if (handler) {
+                handler();
+            }
+        },
+    },
+});

--- a/src/store/updateStore.ts
+++ b/src/store/updateStore.ts
@@ -1,0 +1,131 @@
+import {defineStore} from 'pinia';
+import {defaultPersist} from '@/types/persist';
+import packageInfo from '../../package.json';
+import {compareVersions, resolveVersionLabel} from '@/util/version';
+
+const GITHUB_LATEST_RELEASE_API = 'https://api.github.com/repos/legiz-ru/Prizrak-Box/releases/latest';
+
+type CheckStatus = 'idle' | 'checking' | 'update-available' | 'up-to-date' | 'error';
+
+interface UpdateState {
+    currentVersion: string;
+    latestTag: string | null;
+    latestName: string | null;
+    latestUrl: string | null;
+    publishedAt: string | null;
+    lastChecked: number | null;
+    updateAvailable: boolean;
+    dismissedTag: string | null;
+    notifiedTag: string | null;
+    checking: boolean;
+    lastCheckStatus: CheckStatus;
+    lastError: string | null;
+}
+
+export const useUpdateStore = defineStore('updates', {
+    state: (): UpdateState => ({
+        currentVersion: typeof packageInfo.version === 'string' ? packageInfo.version : '',
+        latestTag: null,
+        latestName: null,
+        latestUrl: null,
+        publishedAt: null,
+        lastChecked: null,
+        updateAvailable: false,
+        dismissedTag: null,
+        notifiedTag: null,
+        checking: false,
+        lastCheckStatus: 'idle',
+        lastError: null,
+    }),
+    getters: {
+        hasVisibleUpdate(state): boolean {
+            return state.updateAvailable && !!state.latestTag && state.latestTag !== state.dismissedTag;
+        },
+        latestDisplayName(state): string {
+            return resolveVersionLabel(state.latestTag, state.latestName);
+        },
+        shouldNotify(state): boolean {
+            return state.updateAvailable
+                && !!state.latestTag
+                && state.latestTag !== state.dismissedTag
+                && state.latestTag !== state.notifiedTag;
+        },
+    },
+    actions: {
+        async checkForUpdates(): Promise<boolean> {
+            if (this.checking) {
+                return this.updateAvailable;
+            }
+
+            const previousTag = this.latestTag;
+            this.checking = true;
+            this.lastError = null;
+            this.lastCheckStatus = 'checking';
+
+            try {
+                const response = await fetch(GITHUB_LATEST_RELEASE_API, {
+                    headers: {
+                        'Accept': 'application/vnd.github+json',
+                        'User-Agent': 'Prizrak-Box',
+                    },
+                });
+
+                if (!response.ok) {
+                    throw new Error(`GitHub responded with status ${response.status}`);
+                }
+
+                const data = await response.json();
+                const tagName = typeof data?.tag_name === 'string' ? data.tag_name : '';
+                const htmlUrl = typeof data?.html_url === 'string' ? data.html_url : '';
+                const name = typeof data?.name === 'string' ? data.name : '';
+                const publishedAt = typeof data?.published_at === 'string' ? data.published_at : null;
+
+                this.latestTag = tagName || null;
+                this.latestName = name || null;
+                this.latestUrl = htmlUrl || null;
+                this.publishedAt = publishedAt;
+                this.lastChecked = Date.now();
+
+                const hasTag = !!tagName;
+                const isNewer = hasTag && compareVersions(tagName, this.currentVersion) > 0;
+                this.updateAvailable = Boolean(isNewer);
+
+                if (!this.updateAvailable) {
+                    this.dismissedTag = null;
+                    this.notifiedTag = null;
+                } else if (previousTag !== this.latestTag) {
+                    this.dismissedTag = null;
+                    this.notifiedTag = null;
+                }
+
+                this.lastCheckStatus = this.updateAvailable ? 'update-available' : 'up-to-date';
+            } catch (error: any) {
+                this.lastCheckStatus = 'error';
+                this.lastError = typeof error?.message === 'string' ? error.message : String(error);
+            } finally {
+                this.checking = false;
+            }
+
+            return this.updateAvailable;
+        },
+        dismissCurrentUpdate() {
+            if (this.latestTag) {
+                this.dismissedTag = this.latestTag;
+            }
+        },
+        markNotified() {
+            if (this.latestTag) {
+                this.notifiedTag = this.latestTag;
+            }
+        },
+        resetNotificationState() {
+            this.notifiedTag = null;
+            this.dismissedTag = null;
+        },
+        clearStatus() {
+            this.lastCheckStatus = 'idle';
+            this.lastError = null;
+        },
+    },
+    persist: defaultPersist,
+});

--- a/src/store/webStore.ts
+++ b/src/store/webStore.ts
@@ -1,6 +1,6 @@
 import {defineStore} from 'pinia';
 
-interface CustomDashboard {
+export interface CustomDashboard {
     name: string;
     url: string;
 }

--- a/src/store/webStore.ts
+++ b/src/store/webStore.ts
@@ -1,5 +1,10 @@
 import {defineStore} from 'pinia';
 
+interface CustomDashboard {
+    name: string;
+    url: string;
+}
+
 export const useWebStore = defineStore('web', {
     state: () => ({
         host: '127.0.0.1', // 默认值
@@ -9,6 +14,7 @@ export const useWebStore = defineStore('web', {
         dnd: false,         // 拖拽显示
         dProfile: [],         // 传输文件 拖拽添加文件用
         fProfile: {}, // 更新profile 配置切换用
+        customDashboards: [] as CustomDashboard[],
     }),
     getters: {
         // 确保使用 state 参数引用正确
@@ -32,6 +38,16 @@ export const useWebStore = defineStore('web', {
             }
             // 在头部添加新日志
             this.logs.unshift(log);
+        },
+        addCustomDashboard(dashboard: CustomDashboard) {
+            this.customDashboards.push(dashboard);
+        },
+        removeCustomDashboard(index: number) {
+            if (index < 0 || index >= this.customDashboards.length) {
+                return;
+            }
+
+            this.customDashboards.splice(index, 1);
         },
     },
     persist: true,

--- a/src/util/axiosRequest.ts
+++ b/src/util/axiosRequest.ts
@@ -1,4 +1,4 @@
-import axios, {AxiosInstance, AxiosResponse} from 'axios';
+import axios, {AxiosInstance, AxiosRequestConfig, AxiosResponse} from 'axios';
 
 // axios的封装
 export class AxiosRequest {
@@ -48,23 +48,23 @@ export class AxiosRequest {
         );
     }
 
-    get<T>(url: string, params?: any): Promise<AxiosResponse<T, any>> {
-        return this.instance.get<T>(url, params);
+    get<T>(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse<T, any>> {
+        return this.instance.get<T>(url, config);
     }
 
-    post<T>(url: string, params?: any): Promise<AxiosResponse<T, any>> {
-        return this.instance.post<T>(url, params);
+    post<T>(url: string, params?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T, any>> {
+        return this.instance.post<T>(url, params, config);
     }
 
-    put<T>(url: string, params?: any): Promise<AxiosResponse<T, any>> {
-        return this.instance.put<T>(url, params);
+    put<T>(url: string, params?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T, any>> {
+        return this.instance.put<T>(url, params, config);
     }
 
-    patch<T>(url: string, params?: any): Promise<AxiosResponse<T, any>> {
-        return this.instance.patch<T>(url, params);
+    patch<T>(url: string, params?: any, config?: AxiosRequestConfig): Promise<AxiosResponse<T, any>> {
+        return this.instance.patch<T>(url, params, config);
     }
 
-    delete<T>(url: string, params?: any): Promise<AxiosResponse<T, any>> {
-        return this.instance.delete<T>(url, params);
+    delete<T>(url: string, config?: AxiosRequestConfig): Promise<AxiosResponse<T, any>> {
+        return this.instance.delete<T>(url, config);
     }
 }

--- a/src/util/dashboard.ts
+++ b/src/util/dashboard.ts
@@ -1,0 +1,71 @@
+import type {CustomDashboard} from "@/store/webStore";
+import {isHttpOrHttps} from "@/util/format";
+
+export interface DashboardTemplate {
+    key: string;
+    name: string;
+    url: string;
+}
+
+export interface DashboardOption extends DashboardTemplate {
+    isCustom?: boolean;
+}
+
+export interface DashboardLink {
+    key: string;
+    name: string;
+    url: string;
+}
+
+export const defaultDashboards: DashboardTemplate[] = [
+    {
+        key: "metacubexd",
+        name: "MetaCubeXD",
+        url: "https://metacubex.github.io/metacubexd/#/setup?http=true&hostname=%host&port=%port&secret=%secret",
+    },
+    {
+        key: "yacd",
+        name: "Yacd",
+        url: "https://yacd.metacubex.one/?hostname=%host&port=%port&secret=%secret",
+    },
+    {
+        key: "zashboard",
+        name: "Zashboard",
+        url: "https://board.zash.run.place/#/setup?http=true&hostname=%host&port=%port&secret=%secret",
+    },
+];
+
+export const createCustomDashboardOptions = (dashboards: CustomDashboard[]): DashboardOption[] =>
+    dashboards
+        .map((entry, index) => ({
+            key: `custom-${index}`,
+            name: entry.name?.trim() ?? "",
+            url: entry.url?.trim() ?? "",
+            isCustom: true,
+        }))
+        .filter((entry) => entry.name !== "" && entry.url !== "");
+
+export const resolveDashboardOptions = (customDashboards: CustomDashboard[]): DashboardOption[] => [
+    ...defaultDashboards,
+    ...createCustomDashboardOptions(customDashboards),
+];
+
+export const formatDashboardUrl = (
+    template: string,
+    context: { host: string; port: string; secret: string },
+): string => template
+    .replace(/%host/g, context.host)
+    .replace(/%port/g, context.port)
+    .replace(/%secret/g, context.secret);
+
+export const createDashboardLinks = (
+    customDashboards: CustomDashboard[],
+    context: { host: string; port: string; secret: string },
+): DashboardLink[] =>
+    resolveDashboardOptions(customDashboards)
+        .map((dashboard, index) => ({
+            key: dashboard.key || `dashboard-${index}`,
+            name: dashboard.name,
+            url: formatDashboardUrl(dashboard.url, context),
+        }))
+        .filter((link) => link.name !== "" && link.url !== "" && isHttpOrHttps(link.url));

--- a/src/util/version.ts
+++ b/src/util/version.ts
@@ -1,0 +1,58 @@
+export function normalizeVersion(version?: string | null): string {
+    if (!version) {
+        return '';
+    }
+
+    const trimmed = version.trim();
+    if (!trimmed) {
+        return '';
+    }
+
+    const withoutPrefix = trimmed.replace(/^v/i, '');
+    const core = withoutPrefix.split(/[+\-]/)[0];
+    return core.trim();
+}
+
+export function compareVersions(a?: string | null, b?: string | null): number {
+    const left = normalizeVersion(a);
+    const right = normalizeVersion(b);
+
+    if (!left && !right) {
+        return 0;
+    }
+    if (!left) {
+        return -1;
+    }
+    if (!right) {
+        return 1;
+    }
+
+    const leftParts = left.split('.').map((segment) => parseInt(segment, 10) || 0);
+    const rightParts = right.split('.').map((segment) => parseInt(segment, 10) || 0);
+    const length = Math.max(leftParts.length, rightParts.length);
+
+    for (let index = 0; index < length; index += 1) {
+        const leftValue = leftParts[index] ?? 0;
+        const rightValue = rightParts[index] ?? 0;
+        if (leftValue > rightValue) {
+            return 1;
+        }
+        if (leftValue < rightValue) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+export function resolveVersionLabel(tag?: string | null, name?: string | null): string {
+    if (name && name.trim()) {
+        return name.trim();
+    }
+
+    if (tag && tag.trim()) {
+        return tag.trim();
+    }
+
+    return '';
+}


### PR DESCRIPTION
## Summary
- add a cancellable overlay for deep-link profile imports and wire it into the renderer flow
- introduce a persisted update checker that surfaces latest releases in the UI and via notifications
- extend settings with release status messaging and a configurable dashboard selector that supports custom links

## Testing
- npm run lint *(fails: existing lint violations in upstream codebase)*

------
https://chatgpt.com/codex/tasks/task_e_68c983815c0c832c9c2e0f07144ee272