### PR TITLE
Adjust update banner button theme

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,6 @@
         </div>
         <el-button
             class="update-banner__open"
-            type="primary"
             size="small"
             @click="openLatestRelease"
         >
@@ -225,6 +224,15 @@ watch(() => menuStore.background, (nextBackground) => {
 .update-banner__open {
   align-self: stretch;
   width: 100%;
+  --el-button-bg-color: var(--left-item-selected-bg);
+  --el-button-hover-bg-color: var(--left-item-selected-bg);
+  --el-button-active-bg-color: var(--left-item-selected-bg);
+  --el-button-border-color: transparent;
+  --el-button-hover-border-color: transparent;
+  --el-button-active-border-color: transparent;
+  --el-button-text-color: var(--text-color);
+  --el-button-hover-text-color: var(--text-color);
+  --el-button-active-text-color: var(--text-color);
 }
 
 .update-banner__dismiss {


### PR DESCRIPTION
## Summary
- restyle the update banner release button to match the active selection color palette used in Tun and rules controls
- ensure the button inherits text and border colors from the shared theme variables for consistency

## Testing
- npm run lint *(fails: existing lint errors and unresolved module imports)*

------
https://chatgpt.com/codex/tasks/task_e_68caa7cc31f4832cada03663f3a218c4