### PR TITLE
Use machine ID for x-hwid and normalize OS headers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,7 +253,8 @@ jobs:
 
       - name: Compress Executable
         run: |
-          Compress-Archive -Path out/make/* -DestinationPath "macos-${{ matrix.arch }}.zip"
+          cd out/make
+          zip -r ../../macos-${{ matrix.arch }}.zip .
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/src-go/go.mod
+++ b/src-go/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/coreos/go-iptables v0.8.0 // indirect
+	github.com/denisbrodbeck/machineid v1.0.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/dmitryikh/leaves v0.0.0-20230708180554-25d19a787328 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect

--- a/src-go/go.sum
+++ b/src-go/go.sum
@@ -19,6 +19,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
+github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dmitryikh/leaves v0.0.0-20230708180554-25d19a787328 h1:ht/zhLOAy9iiEKTKGkXvpw92Z7O6NK0bIVZVREy0kIE=

--- a/src-go/pkg/utils/httpclient.go
+++ b/src-go/pkg/utils/httpclient.go
@@ -2,16 +2,21 @@ package utils
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/hex"
 	"fmt"
 	"golang.org/x/net/html"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/denisbrodbeck/machineid"
 	"github.com/google/uuid"
 )
 
@@ -26,12 +31,12 @@ var (
 
 // HTTPClientConfig 配置结构
 type HTTPClientConfig struct {
-	EnableHWID    bool
-	Version       string
-	DeviceOS      string
-	DeviceOSVer   string
-	DeviceModel   string
-	UserAgent     string
+	EnableHWID  bool
+	Version     string
+	DeviceOS    string
+	DeviceOSVer string
+	DeviceModel string
+	UserAgent   string
 }
 
 // 全局配置，可通过API更新
@@ -42,7 +47,24 @@ var globalConfig = &HTTPClientConfig{
 
 // generateHWID 生成唯一设备标识符
 func generateHWID() string {
+	if id, err := machineid.ProtectedID("prizrak-box"); err == nil && id != "" {
+		return id
+	}
+
+	if id, err := machineid.ID(); err == nil && id != "" {
+		return hashString(id)
+	}
+
+	if host, err := os.Hostname(); err == nil && host != "" {
+		return hashString(host)
+	}
+
 	return uuid.New().String()
+}
+
+func hashString(input string) string {
+	sum := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(sum[:])
 }
 
 // 保存生成的HWID，避免每次重新生成
@@ -65,12 +87,12 @@ func buildDeviceHeaders() map[string]string {
 	if !globalConfig.EnableHWID {
 		return nil
 	}
-	
+
 	headers := make(map[string]string)
 	headers["x-hwid"] = deviceHWID
-	
-	if globalConfig.DeviceOS != "" {
-		headers["x-device-os"] = globalConfig.DeviceOS
+
+	if osName := normalizeDeviceOS(globalConfig.DeviceOS); osName != "" {
+		headers["x-device-os"] = osName
 	}
 	if globalConfig.DeviceOSVer != "" {
 		headers["x-ver-os"] = globalConfig.DeviceOSVer
@@ -78,8 +100,26 @@ func buildDeviceHeaders() map[string]string {
 	if globalConfig.DeviceModel != "" {
 		headers["x-device-model"] = globalConfig.DeviceModel
 	}
-	
+
 	return headers
+}
+
+func normalizeDeviceOS(osName string) string {
+	if osName == "" {
+		return ""
+	}
+
+	lower := strings.ToLower(osName)
+	switch {
+	case strings.Contains(lower, "windows"):
+		return "Windows"
+	case strings.Contains(lower, "linux"):
+		return "Linux"
+	case strings.Contains(lower, "mac") || strings.Contains(lower, "darwin"):
+		return "macOS"
+	default:
+		return osName
+	}
 }
 
 // closeResponseBody 关闭 resp.Body 并处理错误（建议放在 defer 中）

--- a/src-go/pkg/utils/httpclient_test.go
+++ b/src-go/pkg/utils/httpclient_test.go
@@ -7,15 +7,13 @@ import (
 func TestGenerateHWID(t *testing.T) {
 	hwid1 := generateHWID()
 	hwid2 := generateHWID()
-	
-	// HWID should be unique
-	if hwid1 == hwid2 {
-		t.Errorf("HWID should be unique, got same HWID: %s", hwid1)
+
+	if hwid1 == "" {
+		t.Fatal("HWID should not be empty")
 	}
-	
-	// HWID should be 36 characters (UUID format)
-	if len(hwid1) != 36 {
-		t.Errorf("HWID should be 36 characters, got %d", len(hwid1))
+
+	if hwid1 != hwid2 {
+		t.Errorf("HWID should be consistent across calls, got '%s' and '%s'", hwid1, hwid2)
 	}
 }
 
@@ -25,12 +23,12 @@ func TestBuildDeviceHeaders(t *testing.T) {
 		EnableHWID: false,
 	}
 	UpdateHTTPClientConfig(config)
-	
+
 	headers := buildDeviceHeaders()
 	if headers != nil {
 		t.Errorf("Expected nil headers when HWID is disabled, got %v", headers)
 	}
-	
+
 	// Test with HWID enabled
 	config = &HTTPClientConfig{
 		EnableHWID:  true,
@@ -39,26 +37,37 @@ func TestBuildDeviceHeaders(t *testing.T) {
 		DeviceModel: "TestDevice",
 	}
 	UpdateHTTPClientConfig(config)
-	
+
 	headers = buildDeviceHeaders()
 	if headers == nil {
 		t.Fatal("Expected headers when HWID is enabled, got nil")
 	}
-	
+
 	if _, exists := headers["x-hwid"]; !exists {
 		t.Error("Expected x-hwid header")
 	}
-	
+
 	if headers["x-device-os"] != "Linux" {
 		t.Errorf("Expected x-device-os to be 'Linux', got '%s'", headers["x-device-os"])
 	}
-	
+
 	if headers["x-ver-os"] != "5.4.0" {
 		t.Errorf("Expected x-ver-os to be '5.4.0', got '%s'", headers["x-ver-os"])
 	}
-	
+
 	if headers["x-device-model"] != "TestDevice" {
 		t.Errorf("Expected x-device-model to be 'TestDevice', got '%s'", headers["x-device-model"])
+	}
+
+	config = &HTTPClientConfig{
+		EnableHWID: true,
+		DeviceOS:   "Windows x64",
+	}
+	UpdateHTTPClientConfig(config)
+
+	headers = buildDeviceHeaders()
+	if headers["x-device-os"] != "Windows" {
+		t.Errorf("Expected x-device-os to be 'Windows', got '%s'", headers["x-device-os"])
 	}
 }
 
@@ -69,18 +78,18 @@ func TestUpdateHTTPClientConfig(t *testing.T) {
 		Version:    "1.0.1",
 	}
 	UpdateHTTPClientConfig(config)
-	
+
 	expected := "prizrak-box/1.0.1"
 	if globalConfig.UserAgent != expected {
 		t.Errorf("Expected user agent '%s', got '%s'", expected, globalConfig.UserAgent)
 	}
-	
+
 	// Test user agent with HWID disabled
 	config = &HTTPClientConfig{
 		EnableHWID: false,
 	}
 	UpdateHTTPClientConfig(config)
-	
+
 	expected = "clash-verge/v2.3.0"
 	if globalConfig.UserAgent != expected {
 		t.Errorf("Expected user agent '%s', got '%s'", expected, globalConfig.UserAgent)


### PR DESCRIPTION
## Summary
- derive the x-hwid header from the machine identifier with deterministic fallbacks instead of random UUIDs
- normalize the x-device-os header to send canonical OS names and cover the behavior with unit tests
- add the machineid dependency used for hardware identifier resolution

## Testing
- go test ./pkg/utils -run Test

------
https://chatgpt.com/codex/tasks/task_e_68cba4d6e4b4832cb1a99919a5eb80a0