### PR TITLE
Fix HWID initialization and localize request error messages

### DIFF
--- a/src/components/setting/MyConfig.vue
+++ b/src/components/setting/MyConfig.vue
@@ -145,30 +145,6 @@ watch(() => settingStore.startup, (newValue) => {
   pUpdateMihomo(menuStore, settingStore, api)
 });
 
-// HWID设置
-watch(() => settingStore.hwid, async (newValue) => {
-  await updateHTTPClientConfig();
-});
-
-// 更新HTTP客户端配置
-async function updateHTTPClientConfig() {
-  try {
-    // 获取版本号
-    const version = await api.getVersion();
-    
-    // 更新HTTP客户端配置
-    await api.updateHTTPClientConfig({
-      enableHWID: settingStore.hwid,
-      version: version,
-      deviceOS: homeStore.os,
-      deviceOSVer: "", // 可以从系统信息获取，暂时留空
-      deviceModel: "", // 可以从系统信息获取，暂时留空
-    });
-  } catch (e) {
-    console.error("Failed to update HTTP client config:", e);
-  }
-}
-
 // 打开配置目录
 function pxConfigDir() {
   // @ts-ignore
@@ -193,11 +169,6 @@ watch(dashboardDialogVisible, (visible) => {
     newDashboard.name = '';
     newDashboard.url = '';
   }
-});
-
-// 初始化HTTP客户端配置
-onMounted(async () => {
-  await updateHTTPClientConfig();
 });
 
 </script>

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -274,3 +274,11 @@ tray:
   proxy: Proxy
   tun: TUN
   quit: Quit
+
+errors:
+  request-failed: Request failed
+  request-send-failed: Failed to send request
+  request-create-failed: Failed to create request
+  response-empty: Response body is empty
+  unknown-reason: Unknown reason
+

--- a/src/locales/ru.yaml
+++ b/src/locales/ru.yaml
@@ -274,3 +274,11 @@ tray:
   proxy: Прокси
   tun: TUN
   quit: Выйти
+
+errors:
+  request-failed: Не удалось выполнить запрос
+  request-send-failed: Не удалось отправить запрос
+  request-create-failed: Не удалось создать запрос
+  response-empty: Пустой ответ сервера
+  unknown-reason: Неизвестная причина
+

--- a/src/locales/zh.yaml
+++ b/src/locales/zh.yaml
@@ -275,6 +275,10 @@ tray:
   tun: Tun模式
   quit: 退出
 
-
-
+errors:
+  request-failed: 请求失败
+  request-send-failed: 发送请求失败
+  request-create-failed: 创建请求失败
+  response-empty: 响应内容为空
+  unknown-reason: 原因未知
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import {useMenuStore} from "@/store/menuStore";
 import {useWebStore} from "@/store/webStore";
 import {AxiosRequest} from "@/util/axiosRequest";
 import {useHomeStore} from "@/store/homeStore";
+import {useSettingStore} from "@/store/settingStore";
 import {memoryCache} from "@/types/persist"
 import {detectLanguage} from "@/util/menu";
 import createApi from "@/api";
@@ -85,6 +86,18 @@ async function bootstrap() {
     app.use(i18n);
     app.use(router);
 
+    const translate = (key: string, values?: Record<string, unknown>) => {
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+            return i18n.global.t(key, values);
+        } catch {
+            return key;
+        }
+    };
+
+    (app.config.globalProperties as any).$translate = translate;
+    (window as any).pxTranslate = translate;
+
     // 获取api地址、端口、密钥
     const url = window.location.search;
     const params = new URLSearchParams(url);
@@ -128,6 +141,30 @@ async function bootstrap() {
         webStore.secret
     );
 
+    const api = createApi(app.config.globalProperties);
+
+    const homeStore = useHomeStore();
+    const settingStore = useSettingStore();
+
+    const updateHttpClientConfig = async () => {
+        try {
+            const version = await api.getVersion();
+            await api.updateHTTPClientConfig({
+                enableHWID: settingStore.hwid,
+                version,
+                deviceOS: homeStore.os,
+                deviceOSVer: "",
+                deviceModel: "",
+            });
+        } catch (error) {
+            console.error("Failed to update HTTP client config", error);
+        }
+    };
+
+    watch(() => settingStore.hwid, () => {
+        void updateHttpClientConfig();
+    });
+
     setupDeepLinkHandler();
     setupUpdateChecker();
 
@@ -145,13 +182,13 @@ async function bootstrap() {
     }
 
     // 设置起始时间 和 操作系统类型
-    const homeStore = useHomeStore();
-
     // 获取系统类型
     homeStore.setOS(window.pxOs());
 
     // 设置软件开始时间
     homeStore.setStartTime(Date.now());
+
+    await updateHttpClientConfig();
 
 }
 

--- a/src/util/pLoad.ts
+++ b/src/util/pLoad.ts
@@ -1,5 +1,47 @@
 import {ElLoading, ElMessage} from "element-plus";
 
+function translateErrorSegment(key: string, fallback: string): string {
+    const translator = (window as any)?.pxTranslate;
+    if (typeof translator === "function") {
+        try {
+            const result = translator(key);
+            if (typeof result === "string" && result !== key) {
+                return result;
+            }
+        } catch (error) {
+            console.error("Failed to translate error segment", error);
+        }
+    }
+
+    return fallback;
+}
+
+function normalizeErrorMessage(message: unknown): string {
+    if (message === undefined || message === null) {
+        return "";
+    }
+
+    const text = typeof message === "string" ? message : String(message);
+
+    const replacements: Array<[RegExp, string, string]> = [
+        [/请求失败/g, "errors.request-failed", "Request failed"],
+        [/发送请求失败/g, "errors.request-send-failed", "Failed to send request"],
+        [/创建请求失败/g, "errors.request-create-failed", "Failed to create request"],
+        [/响应内容为空/g, "errors.response-empty", "Response body is empty"],
+        [/未知原因/g, "errors.unknown-reason", "Unknown reason"],
+    ];
+
+    let translated = text;
+    for (const [pattern, key, fallback] of replacements) {
+        if (pattern.test(translated)) {
+            const value = translateErrorSegment(key, fallback);
+            translated = translated.replace(pattern, value);
+        }
+    }
+
+    return translated;
+}
+
 export async function pLoad(tip: any, callback: any) {
     const loading = ElLoading.service({
         lock: true,
@@ -30,7 +72,7 @@ export function pSuccess(msg: any) {
 
 export function pError(msg: any) {
     ElMessage({
-        message: msg,
+        message: normalizeErrorMessage(msg),
         type: "error",
         duration: 5000,
         grouping: true


### PR DESCRIPTION
## Summary
- initialize the HTTP client configuration with HWID data during app bootstrap and update it when the toggle changes
- expose a global translation helper so utilities can access localized strings outside of components
- translate HWID-related HTTP error messages using new locale entries for Russian, English, and Chinese

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc2325778832c87a2d3b20c4ba7fc