### PR TITLE
refactor: update profile usage display

### DIFF
--- a/src/locales/ru.yaml
+++ b/src/locales/ru.yaml
@@ -166,9 +166,9 @@ profiles:
   paste: Импорт из буфера обмена
   open: Импорт из файла
   available: Доступно
-  use: Используется
+  use: Использовано
   expire: Истекает
-  update: Обновить
+  update: Обновлено:
   placeholder: Подписка, ShareLink, Yaml, Base64, Json
   home: Перейти на страницу подписки
   support: Перейти на страницу поддержки

--- a/src/locales/ru.yaml
+++ b/src/locales/ru.yaml
@@ -168,7 +168,7 @@ profiles:
   available: Доступно
   use: Использовано
   expire: Истекает
-  update: Обновлено
+  update: "Обновлено:"
   placeholder: Подписка, ShareLink, Yaml, Base64, Json
   home: Перейти на страницу подписки
   support: Перейти на страницу поддержки

--- a/src/locales/ru.yaml
+++ b/src/locales/ru.yaml
@@ -168,7 +168,7 @@ profiles:
   available: Доступно
   use: Использовано
   expire: Истекает
-  update: Обновлено:
+  update: Обновлено
   placeholder: Подписка, ShareLink, Yaml, Base64, Json
   home: Перейти на страницу подписки
   support: Перейти на страницу поддержки

--- a/src/views/Profiles.vue
+++ b/src/views/Profiles.vue
@@ -721,7 +721,7 @@ watch(() => webStore.dProfile, async (pList) => {
 
 
 .sub-card {
-  padding: 5px 8px 5px 5px;
+  padding: 5px 8px 0 5px;
   border: 2px solid var(--sub-card-border);
   border-radius: 8px;
   background: var(--sub-card-bg);
@@ -752,7 +752,7 @@ watch(() => webStore.dProfile, async (pList) => {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 6px 12px 8px 12px;
+  padding: 6px 12px 0 12px;
   color: var(--text-color);
   flex: 1;
 }
@@ -819,7 +819,7 @@ watch(() => webStore.dProfile, async (pList) => {
   justify-content: flex-end;
   gap: 8px;
   margin-top: 6px;
-  padding-top: 2px;
+  padding: 0;
   color: var(--text-color);
   align-items: center;
 }

--- a/src/views/Profiles.vue
+++ b/src/views/Profiles.vue
@@ -36,6 +36,31 @@ const formatBytes = (value: unknown) => {
   return prettyBytes(number)
 }
 
+const formatDate = (value: unknown) => {
+  if (!hasUsageValue(value)) {
+    return ''
+  }
+
+  if (typeof value === 'string') {
+    const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+    if (match) {
+      const [, year, month, day] = match
+      return `${day}.${month}.${year}`
+    }
+  }
+
+  const date = new Date(value as any)
+  if (Number.isNaN(date.getTime())) {
+    return `${value}`
+  }
+
+  const day = String(date.getDate()).padStart(2, '0')
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const year = date.getFullYear()
+
+  return `${day}.${month}.${year}`
+}
+
 // 头部几个按钮操作
 const addFormVisible = ref(false)
 const isNowAdd = ref(false)
@@ -449,22 +474,21 @@ watch(() => webStore.dProfile, async (pList) => {
                   class="drag">
                 <icon-mdi-drag/>
               </el-icon>
+              <div class="profile-name" :title="data.title">
+                {{ data.title }}
+              </div>
               <el-tooltip
                   v-if="data.type == 1"
                   :content="$t('refresh')"
                   placement="top">
                 <el-icon size="22"
-                         class="ops"
+                         class="ops row-refresh"
                          @click.stop="refresh(data)">
                   <icon-mdi-refresh/>
                 </el-icon>
               </el-tooltip>
-
             </div>
             <div class="system-info">
-              <div class="profile-title" :title="data.title">
-                {{ data.title }}
-              </div>
               <div
                   v-if="hasUsageValue(data.available) || hasUsageValue(data.used) || hasUsageValue(data.expire) || hasUsageValue(data.update)"
                   class="profile-stats"
@@ -480,7 +504,7 @@ watch(() => webStore.dProfile, async (pList) => {
                 </div>
                 <div class="profile-stat" v-if="hasUsageValue(data.used)">
                   <div class="profile-stat-label">
-                    <icon-mdi-database-minus/>
+                    <icon-mdi-arrow-up-bold-box-outline/>
                     <span>{{ $t('profiles.use') }}</span>
                   </div>
                   <div class="profile-stat-value">
@@ -493,7 +517,7 @@ watch(() => webStore.dProfile, async (pList) => {
                     <span>{{ $t('profiles.expire') }}</span>
                   </div>
                   <div class="profile-stat-value">
-                    {{ data.expire }}
+                    {{ formatDate(data.expire) }}
                   </div>
                 </div>
                 <div class="profile-stat" v-if="hasUsageValue(data.update)">
@@ -502,7 +526,7 @@ watch(() => webStore.dProfile, async (pList) => {
                     <span>{{ $t('profiles.update') }}</span>
                   </div>
                   <div class="profile-stat-value">
-                    {{ data.update }}
+                    {{ formatDate(data.update) }}
                   </div>
                 </div>
               </div>
@@ -703,6 +727,7 @@ watch(() => webStore.dProfile, async (pList) => {
   max-width: 245px;
 }
 
+
 .sub-card {
   padding: 5px 8px 5px 5px;
   border: 2px solid var(--sub-card-border);
@@ -711,6 +736,9 @@ watch(() => webStore.dProfile, async (pList) => {
   color: var(--text-color);
   box-shadow: var(--left-nav-shadow);
   margin-top: 5px;
+  display: flex;
+  flex-direction: column;
+  min-height: 190px;
 }
 
 .sub-card:hover, .sub-card-select {
@@ -725,7 +753,24 @@ watch(() => webStore.dProfile, async (pList) => {
 
 .sub-card .row {
   display: flex;
-  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  justify-content: flex-start;
+}
+
+.row-refresh {
+  margin-left: auto;
+}
+
+.profile-name {
+  flex: 1;
+  font-size: 15px;
+  font-weight: 600;
+  text-align: center;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: var(--text-color);
 }
 
 .sub-card .row .drag:hover {
@@ -737,41 +782,31 @@ watch(() => webStore.dProfile, async (pList) => {
 }
 
 .system-info {
+  flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  justify-content: flex-start;
   padding: 5px 10px 5px 15px;
   color: var(--text-color);
 }
 
-.profile-title {
-  font-size: 15px;
-  font-weight: 600;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
 .profile-stats {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 6px;
 }
 
 .profile-stat {
   display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 6px 8px;
-  border-radius: 6px;
-  background-color: var(--sub-card-bg);
-  border: 1px solid var(--sub-card-border);
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
 }
 
 .profile-stat-label {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   color: var(--placeholder-color);
   font-size: 12px;
 }
@@ -789,7 +824,7 @@ watch(() => webStore.dProfile, async (pList) => {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  margin-top: 10px;
+  margin-top: auto;
   margin-bottom: 4px;
   color: var(--text-color);
 }

--- a/src/views/Profiles.vue
+++ b/src/views/Profiles.vue
@@ -461,122 +461,123 @@ watch(() => webStore.dProfile, async (pList) => {
           :draggable="canDrag"
           style="margin-left: 10px;width: 95%;"
       >
-        <template v-slot:VDC="{data,index}">
-          <div
-              :class="data.selected?'sub-card sub-card-select':'sub-card'"
-              @click="switchProfile(data)"
-          >
-            <div class="row">
-              <el-icon
-                  @mouseenter.stop="mouseEnter"
-                  @mouseleave.stop="mouseLeave"
-                  size="22"
-                  class="drag">
-                <icon-mdi-drag/>
-              </el-icon>
-              <div class="profile-name" :title="data.title">
-                {{ data.title }}
-              </div>
-              <el-tooltip
-                  v-if="data.type == 1"
-                  :content="$t('refresh')"
-                  placement="top">
-                <el-icon size="22"
-                         class="ops row-refresh"
-                         @click.stop="refresh(data)">
-                  <icon-mdi-refresh/>
-                </el-icon>
-              </el-tooltip>
-            </div>
-            <div class="system-info">
-              <div
-                  v-if="hasUsageValue(data.available) || hasUsageValue(data.used) || hasUsageValue(data.expire) || hasUsageValue(data.update)"
-                  class="profile-stats"
-              >
-                <div class="profile-stat" v-if="hasUsageValue(data.available)">
-                  <div class="profile-stat-label">
-                    <icon-mdi-database-check/>
-                    <span>{{ $t('profiles.available') }}</span>
-                  </div>
-                  <div class="profile-stat-value">
-                    {{ formatBytes(data.available) }}
-                  </div>
-                </div>
-                <div class="profile-stat" v-if="hasUsageValue(data.used)">
-                  <div class="profile-stat-label">
-                    <icon-mdi-arrow-up-bold-box-outline/>
-                    <span>{{ $t('profiles.use') }}</span>
-                  </div>
-                  <div class="profile-stat-value">
-                    {{ formatBytes(data.used) }}
-                  </div>
-                </div>
-                <div class="profile-stat" v-if="hasUsageValue(data.expire)">
-                  <div class="profile-stat-label">
-                    <icon-mdi-timer-outline/>
-                    <span>{{ $t('profiles.expire') }}</span>
-                  </div>
-                  <div class="profile-stat-value">
-                    {{ formatDate(data.expire) }}
-                  </div>
-                </div>
-                <div class="profile-stat" v-if="hasUsageValue(data.update)">
-                  <div class="profile-stat-label">
-                    <icon-mdi-update/>
-                    <span>{{ $t('profiles.update') }}</span>
-                  </div>
-                  <div class="profile-stat-value">
-                    {{ formatDate(data.update) }}
-                  </div>
-                </div>
-              </div>
-              <div class="bottom-row">
-                <el-tooltip
-                    v-if="data.support"
-                    :content="$t('profiles.support')"
-                    placement="top">
+          <template v-slot:VDC="{data,index}">
+            <div
+                :class="data.selected?'sub-card sub-card-select':'sub-card'"
+                @click="switchProfile(data)"
+            >
+              <div class="system-info">
+                <div class="profile-title">
                   <el-icon
-                    class="ops"
-                    @click.stop="goSupport(data)"
-                    size="20">
-                  <icon-mdi-face-agent/>
-                </el-icon>
-              </el-tooltip>
-              <el-tooltip
-                  v-if="data.home"
-                  :content="$t('profiles.home')"
-                  placement="top">
-                <el-icon
-                    class="ops"
-                    @click.stop="goHome(data)"
-                    size="20">
-                  <icon-mdi-home-import-outline/>
-                </el-icon>
-              </el-tooltip>
-              <el-tooltip
-                  :content="$t('edit')"
-                  placement="top">
-                <el-icon
-                    class="ops"
-                    @click.stop="updateProfile(data)"
-                    size="20">
-                  <icon-mdi-square-edit-outline/>
-                </el-icon>
-              </el-tooltip>
-              <el-tooltip
-                  :content="$t('delete')"
-                  placement="top">
-                <el-icon
-                    class="ops"
-                    @click.stop="deleteProfile(data,index)"
-                    size="20">
-                  <icon-mdi-trash-can/>
-                </el-icon>
-              </el-tooltip>
+                      @mouseenter.stop="mouseEnter"
+                      @mouseleave.stop="mouseLeave"
+                      size="22"
+                      class="drag">
+                    <icon-mdi-drag/>
+                  </el-icon>
+                  <span class="profile-title-text" :title="data.title">
+                    {{ data.title }}
+                  </span>
+                  <el-tooltip
+                      v-if="data.type == 1"
+                      :content="$t('refresh')"
+                      placement="top">
+                    <el-icon size="22"
+                             class="ops row-refresh"
+                             @click.stop="refresh(data)">
+                      <icon-mdi-refresh/>
+                    </el-icon>
+                  </el-tooltip>
+                </div>
+                <div
+                    v-if="hasUsageValue(data.available) || hasUsageValue(data.used) || hasUsageValue(data.expire) || hasUsageValue(data.update)"
+                    class="profile-stats"
+                >
+                  <div class="profile-stat" v-if="hasUsageValue(data.available)">
+                    <div class="profile-stat-label">
+                      <icon-mdi-database-check/>
+                      <span>{{ $t('profiles.available') }}</span>
+                    </div>
+                    <div class="profile-stat-value">
+                      {{ formatBytes(data.available) }}
+                    </div>
+                  </div>
+                  <div class="profile-stat" v-if="hasUsageValue(data.used)">
+                    <div class="profile-stat-label">
+                      <icon-mdi-arrow-up-bold-box-outline/>
+                      <span>{{ $t('profiles.use') }}</span>
+                    </div>
+                    <div class="profile-stat-value">
+                      {{ formatBytes(data.used) }}
+                    </div>
+                  </div>
+                  <div class="profile-stat" v-if="hasUsageValue(data.expire)">
+                    <div class="profile-stat-label">
+                      <icon-mdi-timer-outline/>
+                      <span>{{ $t('profiles.expire') }}</span>
+                    </div>
+                    <div class="profile-stat-value">
+                      {{ formatDate(data.expire) }}
+                    </div>
+                  </div>
+                  <div class="profile-stat" v-if="hasUsageValue(data.update)">
+                    <div class="profile-stat-label">
+                      <icon-mdi-update/>
+                      <span>{{ $t('profiles.update') }}</span>
+                    </div>
+                    <div class="profile-stat-value">
+                      {{ formatDate(data.update) }}
+                    </div>
+                  </div>
+                </div>
+                <div class="bottom-row">
+                  <el-tooltip
+                      v-if="data.support"
+                      :content="$t('profiles.support')"
+                      placement="top">
+                    <el-icon
+                        class="ops"
+                        @click.stop="goSupport(data)"
+                        size="20">
+                      <icon-mdi-face-agent/>
+                    </el-icon>
+                  </el-tooltip>
+                  <el-tooltip
+                      v-if="data.home"
+                      :content="$t('profiles.home')"
+                      placement="top">
+                    <el-icon
+                        class="ops"
+                        @click.stop="goHome(data)"
+                        size="20">
+                      <icon-mdi-home-import-outline/>
+                    </el-icon>
+                  </el-tooltip>
+                  <el-tooltip
+                      :content="$t('edit')"
+                      placement="top">
+                    <el-icon
+                        class="ops"
+                        @click.stop="updateProfile(data)"
+                        size="20">
+                      <icon-mdi-square-edit-outline/>
+                    </el-icon>
+                  </el-tooltip>
+                  <el-tooltip
+                      :content="$t('delete')"
+                      placement="top">
+                    <el-icon
+                        class="ops"
+                        @click.stop="deleteProfile(data,index)"
+                        size="20">
+                      <icon-mdi-trash-can/>
+                    </el-icon>
+                  </el-tooltip>
+                </div>
+              </div>
             </div>
-          </div>
-        </template>
-      </VDContainer>
+          </template>
+        </VDContainer>
 
     </template>
   </MyLayout>
@@ -750,29 +751,38 @@ watch(() => webStore.dProfile, async (pList) => {
   cursor: default;
 }
 
-.sub-card .row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  justify-content: flex-start;
-}
 
 .row-refresh {
   margin-left: auto;
 }
 
-.profile-name {
+.system-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 12px 10px 12px;
+  color: var(--text-color);
   flex: 1;
-  font-size: 15px;
+}
+
+.profile-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   font-weight: 600;
+  font-size: 15px;
+  color: var(--text-color);
+}
+
+.profile-title-text {
+  flex: 1;
   text-align: center;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  color: var(--text-color);
 }
 
-.sub-card .row .drag:hover {
+.profile-title .drag:hover {
   cursor: grab;
 }
 
@@ -780,25 +790,21 @@ watch(() => webStore.dProfile, async (pList) => {
   cursor: pointer;
 }
 
-.system-info {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 5px 10px 5px 15px;
-  color: var(--text-color);
-}
-
 .profile-stats {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  grid-auto-flow: row dense;
 }
 
 .profile-stat {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background-color: rgba(255, 255, 255, 0.05);
+  background-color: color-mix(in srgb, var(--text-color) 8%, transparent);
 }
 
 .profile-stat-label {
@@ -822,8 +828,10 @@ watch(() => webStore.dProfile, async (pList) => {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  margin-top: 0;
+  margin-top: auto;
+  padding-top: 4px;
   color: var(--text-color);
+  align-items: center;
 }
 
 

--- a/src/views/Profiles.vue
+++ b/src/views/Profiles.vue
@@ -494,40 +494,32 @@ watch(() => webStore.dProfile, async (pList) => {
                     class="profile-stats"
                 >
                   <div class="profile-stat" v-if="hasUsageValue(data.available)">
-                    <div class="profile-stat-label">
+                    <el-icon class="profile-stat-icon">
                       <icon-mdi-database-check/>
-                      <span>{{ $t('profiles.available') }}</span>
-                    </div>
-                    <div class="profile-stat-value">
-                      {{ formatBytes(data.available) }}
-                    </div>
+                    </el-icon>
+                    <span class="profile-stat-label">{{ $t('profiles.available') }}</span>
+                    <span class="profile-stat-value">{{ formatBytes(data.available) }}</span>
                   </div>
                   <div class="profile-stat" v-if="hasUsageValue(data.used)">
-                    <div class="profile-stat-label">
+                    <el-icon class="profile-stat-icon">
                       <icon-mdi-arrow-up-bold-box-outline/>
-                      <span>{{ $t('profiles.use') }}</span>
-                    </div>
-                    <div class="profile-stat-value">
-                      {{ formatBytes(data.used) }}
-                    </div>
+                    </el-icon>
+                    <span class="profile-stat-label">{{ $t('profiles.use') }}</span>
+                    <span class="profile-stat-value">{{ formatBytes(data.used) }}</span>
                   </div>
                   <div class="profile-stat" v-if="hasUsageValue(data.expire)">
-                    <div class="profile-stat-label">
+                    <el-icon class="profile-stat-icon">
                       <icon-mdi-timer-outline/>
-                      <span>{{ $t('profiles.expire') }}</span>
-                    </div>
-                    <div class="profile-stat-value">
-                      {{ formatDate(data.expire) }}
-                    </div>
+                    </el-icon>
+                    <span class="profile-stat-label">{{ $t('profiles.expire') }}</span>
+                    <span class="profile-stat-value">{{ formatDate(data.expire) }}</span>
                   </div>
                   <div class="profile-stat" v-if="hasUsageValue(data.update)">
-                    <div class="profile-stat-label">
+                    <el-icon class="profile-stat-icon">
                       <icon-mdi-update/>
-                      <span>{{ $t('profiles.update') }}</span>
-                    </div>
-                    <div class="profile-stat-value">
-                      {{ formatDate(data.update) }}
-                    </div>
+                    </el-icon>
+                    <span class="profile-stat-label">{{ $t('profiles.update') }}</span>
+                    <span class="profile-stat-value">{{ formatDate(data.update) }}</span>
                   </div>
                 </div>
                 <div class="bottom-row">
@@ -760,7 +752,7 @@ watch(() => webStore.dProfile, async (pList) => {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 6px 12px 10px 12px;
+  padding: 6px 12px 8px 12px;
   color: var(--text-color);
   flex: 1;
 }
@@ -791,26 +783,23 @@ watch(() => webStore.dProfile, async (pList) => {
 }
 
 .profile-stats {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-  grid-auto-flow: row dense;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .profile-stat {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
-  padding: 6px 8px;
-  border-radius: 6px;
-  background-color: rgba(255, 255, 255, 0.05);
-  background-color: color-mix(in srgb, var(--text-color) 8%, transparent);
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.profile-stat-icon {
+  color: var(--placeholder-color);
 }
 
 .profile-stat-label {
-  display: flex;
-  align-items: center;
-  gap: 6px;
   color: var(--placeholder-color);
   font-size: 12px;
 }
@@ -819,6 +808,7 @@ watch(() => webStore.dProfile, async (pList) => {
   color: var(--text-color);
   font-weight: 600;
   font-size: 14px;
+  margin-left: auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -828,8 +818,8 @@ watch(() => webStore.dProfile, async (pList) => {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  margin-top: auto;
-  padding-top: 4px;
+  margin-top: 6px;
+  padding-top: 2px;
   color: var(--text-color);
   align-items: center;
 }

--- a/src/views/Profiles.vue
+++ b/src/views/Profiles.vue
@@ -489,82 +489,84 @@ watch(() => webStore.dProfile, async (pList) => {
                     </el-icon>
                   </el-tooltip>
                 </div>
-                <div
-                    v-if="hasUsageValue(data.available) || hasUsageValue(data.used) || hasUsageValue(data.expire) || hasUsageValue(data.update)"
-                    class="profile-stats"
-                >
-                  <div class="profile-stat" v-if="hasUsageValue(data.available)">
-                    <el-icon class="profile-stat-icon">
-                      <icon-mdi-database-check/>
-                    </el-icon>
-                    <span class="profile-stat-label">{{ $t('profiles.available') }}</span>
-                    <span class="profile-stat-value">{{ formatBytes(data.available) }}</span>
+                <div class="profile-body">
+                  <div
+                      v-if="hasUsageValue(data.available) || hasUsageValue(data.used) || hasUsageValue(data.expire) || hasUsageValue(data.update)"
+                      class="profile-stats"
+                  >
+                    <div class="profile-stat" v-if="hasUsageValue(data.available)">
+                      <el-icon class="profile-stat-icon">
+                        <icon-mdi-database-check/>
+                      </el-icon>
+                      <span class="profile-stat-label">{{ $t('profiles.available') }}</span>
+                      <span class="profile-stat-value">{{ formatBytes(data.available) }}</span>
+                    </div>
+                    <div class="profile-stat" v-if="hasUsageValue(data.used)">
+                      <el-icon class="profile-stat-icon">
+                        <icon-mdi-arrow-up-bold-box-outline/>
+                      </el-icon>
+                      <span class="profile-stat-label">{{ $t('profiles.use') }}</span>
+                      <span class="profile-stat-value">{{ formatBytes(data.used) }}</span>
+                    </div>
+                    <div class="profile-stat" v-if="hasUsageValue(data.expire)">
+                      <el-icon class="profile-stat-icon">
+                        <icon-mdi-timer-outline/>
+                      </el-icon>
+                      <span class="profile-stat-label">{{ $t('profiles.expire') }}</span>
+                      <span class="profile-stat-value">{{ formatDate(data.expire) }}</span>
+                    </div>
+                    <div class="profile-stat" v-if="hasUsageValue(data.update)">
+                      <el-icon class="profile-stat-icon">
+                        <icon-mdi-update/>
+                      </el-icon>
+                      <span class="profile-stat-label">{{ $t('profiles.update') }}</span>
+                      <span class="profile-stat-value">{{ formatDate(data.update) }}</span>
+                    </div>
                   </div>
-                  <div class="profile-stat" v-if="hasUsageValue(data.used)">
-                    <el-icon class="profile-stat-icon">
-                      <icon-mdi-arrow-up-bold-box-outline/>
-                    </el-icon>
-                    <span class="profile-stat-label">{{ $t('profiles.use') }}</span>
-                    <span class="profile-stat-value">{{ formatBytes(data.used) }}</span>
+                  <div class="profile-actions">
+                    <el-tooltip
+                        v-if="data.support"
+                        :content="$t('profiles.support')"
+                        placement="top">
+                      <el-icon
+                          class="ops"
+                          @click.stop="goSupport(data)"
+                          size="20">
+                        <icon-mdi-face-agent/>
+                      </el-icon>
+                    </el-tooltip>
+                    <el-tooltip
+                        v-if="data.home"
+                        :content="$t('profiles.home')"
+                        placement="top">
+                      <el-icon
+                          class="ops"
+                          @click.stop="goHome(data)"
+                          size="20">
+                        <icon-mdi-home-import-outline/>
+                      </el-icon>
+                    </el-tooltip>
+                    <el-tooltip
+                        :content="$t('edit')"
+                        placement="top">
+                      <el-icon
+                          class="ops"
+                          @click.stop="updateProfile(data)"
+                          size="20">
+                        <icon-mdi-square-edit-outline/>
+                      </el-icon>
+                    </el-tooltip>
+                    <el-tooltip
+                        :content="$t('delete')"
+                        placement="top">
+                      <el-icon
+                          class="ops"
+                          @click.stop="deleteProfile(data,index)"
+                          size="20">
+                        <icon-mdi-trash-can/>
+                      </el-icon>
+                    </el-tooltip>
                   </div>
-                  <div class="profile-stat" v-if="hasUsageValue(data.expire)">
-                    <el-icon class="profile-stat-icon">
-                      <icon-mdi-timer-outline/>
-                    </el-icon>
-                    <span class="profile-stat-label">{{ $t('profiles.expire') }}</span>
-                    <span class="profile-stat-value">{{ formatDate(data.expire) }}</span>
-                  </div>
-                  <div class="profile-stat" v-if="hasUsageValue(data.update)">
-                    <el-icon class="profile-stat-icon">
-                      <icon-mdi-update/>
-                    </el-icon>
-                    <span class="profile-stat-label">{{ $t('profiles.update') }}</span>
-                    <span class="profile-stat-value">{{ formatDate(data.update) }}</span>
-                  </div>
-                </div>
-                <div class="bottom-row">
-                  <el-tooltip
-                      v-if="data.support"
-                      :content="$t('profiles.support')"
-                      placement="top">
-                    <el-icon
-                        class="ops"
-                        @click.stop="goSupport(data)"
-                        size="20">
-                      <icon-mdi-face-agent/>
-                    </el-icon>
-                  </el-tooltip>
-                  <el-tooltip
-                      v-if="data.home"
-                      :content="$t('profiles.home')"
-                      placement="top">
-                    <el-icon
-                        class="ops"
-                        @click.stop="goHome(data)"
-                        size="20">
-                      <icon-mdi-home-import-outline/>
-                    </el-icon>
-                  </el-tooltip>
-                  <el-tooltip
-                      :content="$t('edit')"
-                      placement="top">
-                    <el-icon
-                        class="ops"
-                        @click.stop="updateProfile(data)"
-                        size="20">
-                      <icon-mdi-square-edit-outline/>
-                    </el-icon>
-                  </el-tooltip>
-                  <el-tooltip
-                      :content="$t('delete')"
-                      placement="top">
-                    <el-icon
-                        class="ops"
-                        @click.stop="deleteProfile(data,index)"
-                        size="20">
-                      <icon-mdi-trash-can/>
-                    </el-icon>
-                  </el-tooltip>
                 </div>
               </div>
             </div>
@@ -715,13 +717,14 @@ watch(() => webStore.dProfile, async (pList) => {
 }
 
 :deep(.vdc-item-container) {
-  width: calc(33% - 10px);
-  max-width: 245px;
+  width: calc(33.333% - 12px);
+  max-width: 260px;
+  min-width: 220px;
 }
 
 
 .sub-card {
-  padding: 5px 8px 0 5px;
+  padding: 8px 10px 0 10px;
   border: 2px solid var(--sub-card-border);
   border-radius: 8px;
   background: var(--sub-card-bg);
@@ -730,7 +733,6 @@ watch(() => webStore.dProfile, async (pList) => {
   margin-top: 5px;
   display: flex;
   flex-direction: column;
-  min-height: 190px;
 }
 
 .sub-card:hover, .sub-card-select {
@@ -751,8 +753,8 @@ watch(() => webStore.dProfile, async (pList) => {
 .system-info {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 6px 12px 0 12px;
+  gap: 8px;
+  padding: 4px 8px 0 8px;
   color: var(--text-color);
   flex: 1;
 }
@@ -782,16 +784,22 @@ watch(() => webStore.dProfile, async (pList) => {
   cursor: pointer;
 }
 
-.profile-stats {
+.profile-body {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 0;
+}
+
+.profile-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px 12px;
 }
 
 .profile-stat {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   font-size: 13px;
 }
 
@@ -814,14 +822,14 @@ watch(() => webStore.dProfile, async (pList) => {
   white-space: nowrap;
 }
 
-.bottom-row {
+.profile-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 8px;
-  margin-top: 6px;
-  padding: 0;
-  color: var(--text-color);
   align-items: center;
+  gap: 8px;
+  margin-top: 0;
+  padding-top: 0;
+  color: var(--text-color);
 }
 
 

--- a/src/views/Profiles.vue
+++ b/src/views/Profiles.vue
@@ -786,7 +786,7 @@ watch(() => webStore.dProfile, async (pList) => {
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  padding: 5px 10px 5px 15px;
+  padding: 5px 10px 0 15px;
   color: var(--text-color);
 }
 
@@ -824,7 +824,7 @@ watch(() => webStore.dProfile, async (pList) => {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  margin-top: auto;
+  margin-top: 6px;
   margin-bottom: 4px;
   color: var(--text-color);
 }

--- a/src/views/Profiles.vue
+++ b/src/views/Profiles.vue
@@ -23,6 +23,19 @@ const menuStore = useMenuStore();
 const proxiesStore = useProxiesStore();
 const webStore = useWebStore();
 
+const hasUsageValue = (value: unknown) => value !== undefined && value !== null && value !== ''
+
+const formatBytes = (value: unknown) => {
+  if (!hasUsageValue(value)) {
+    return ''
+  }
+  const number = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(number)) {
+    return ''
+  }
+  return prettyBytes(number)
+}
+
 // 头部几个按钮操作
 const addFormVisible = ref(false)
 const isNowAdd = ref(false)
@@ -68,37 +81,6 @@ function openFile() {
   webStore.dnd = true
 }
 
-// 头部显示
-const headerShow = reactive({
-  available: '',
-  used: '',
-  expire: '',
-  update: '',
-})
-
-function setHeaderShow(item: any) {
-  if (item['available']) {
-    headerShow.available = prettyBytes(item['available'])
-  } else {
-    headerShow.available = ''
-  }
-  if (item['used']) {
-    headerShow.used = prettyBytes(item['used'])
-  } else {
-    headerShow.used = ''
-  }
-  if (item['expire']) {
-    headerShow.expire = item['expire']
-  } else {
-    headerShow.expire = ''
-  }
-  if (item['update']) {
-    headerShow.update = item['update']
-  } else {
-    headerShow.update = ''
-  }
-}
-
 // 列表显示
 let profiles = reactive<any[]>([])
 
@@ -110,9 +92,6 @@ async function getProfileList() {
   if (list && list.length != 0) {
     list.forEach(item => {
       profiles.push(item)
-      if (item['selected']) {
-        setHeaderShow(item)
-      }
     })
 
     Events.Emit({
@@ -153,7 +132,6 @@ async function switchProfile(data: any) {
         }
       }
       data['selected'] = true
-      setHeaderShow(data)
 
       api.getRuleNum().then((res) => {
         menuStore.setRuleNum(res);
@@ -189,7 +167,6 @@ watch(() => webStore.fProfile, async (data: any) => {
   }
 
   data['selected'] = true
-  setHeaderShow(data)
 })
 
 
@@ -198,9 +175,6 @@ async function refresh(data: any) {
   await pLoad(t('profiles.refresh.ing'), async () => {
     try {
       const re = await api.refreshProfile(data)
-      if (data['selected']) {
-        setHeaderShow(re)
-      }
       Object.assign(data, re);
       pSuccess(t('profiles.refresh.success'))
     } catch (e) {
@@ -452,23 +426,6 @@ watch(() => webStore.dProfile, async (pList) => {
         </div>
       </el-space>
 
-      <div class="sub-title">
-        <template v-if="headerShow.available">
-          <span>{{ $t('profiles.available') }} {{ headerShow.available }}</span>
-          <el-divider direction="vertical" border-style="dashed"/>
-        </template>
-        <template v-if="headerShow.used">
-          <span>{{ $t('profiles.use') }} {{ headerShow.used }}</span>
-          <el-divider direction="vertical" border-style="dashed"/>
-        </template>
-        <template v-if="headerShow.expire">
-          <span>{{ $t('profiles.expire') }} {{ headerShow.expire }}</span>
-          <el-divider direction="vertical" border-style="dashed"/>
-        </template>
-        <template v-if="headerShow.update">
-          <span>{{ $t('profiles.update') }} {{ headerShow.update }}</span>
-        </template>
-      </div>
     </template>
 
     <template #bottom>
@@ -504,12 +461,51 @@ watch(() => webStore.dProfile, async (pList) => {
               </el-tooltip>
 
             </div>
-            <div
-                class="system-info"
-            >
-              <span :title="data.title">
+            <div class="system-info">
+              <div class="profile-title" :title="data.title">
                 {{ data.title }}
-              </span>
+              </div>
+              <div
+                  v-if="hasUsageValue(data.available) || hasUsageValue(data.used) || hasUsageValue(data.expire) || hasUsageValue(data.update)"
+                  class="profile-stats"
+              >
+                <div class="profile-stat" v-if="hasUsageValue(data.available)">
+                  <div class="profile-stat-label">
+                    <icon-mdi-database-check/>
+                    <span>{{ $t('profiles.available') }}</span>
+                  </div>
+                  <div class="profile-stat-value">
+                    {{ formatBytes(data.available) }}
+                  </div>
+                </div>
+                <div class="profile-stat" v-if="hasUsageValue(data.used)">
+                  <div class="profile-stat-label">
+                    <icon-mdi-database-minus/>
+                    <span>{{ $t('profiles.use') }}</span>
+                  </div>
+                  <div class="profile-stat-value">
+                    {{ formatBytes(data.used) }}
+                  </div>
+                </div>
+                <div class="profile-stat" v-if="hasUsageValue(data.expire)">
+                  <div class="profile-stat-label">
+                    <icon-mdi-timer-outline/>
+                    <span>{{ $t('profiles.expire') }}</span>
+                  </div>
+                  <div class="profile-stat-value">
+                    {{ data.expire }}
+                  </div>
+                </div>
+                <div class="profile-stat" v-if="hasUsageValue(data.update)">
+                  <div class="profile-stat-label">
+                    <icon-mdi-update/>
+                    <span>{{ $t('profiles.update') }}</span>
+                  </div>
+                  <div class="profile-stat-value">
+                    {{ data.update }}
+                  </div>
+                </div>
+              </div>
             </div>
             <div class="bottom-row">
               <el-tooltip
@@ -687,13 +683,6 @@ watch(() => webStore.dProfile, async (pList) => {
   margin-left: 10px;
 }
 
-.sub-title {
-  margin-left: 10px;
-  color: var(--top-hr-color);
-  font-size: 14px;
-  margin-top: 15px;
-}
-
 .profile-option {
   margin-left: 10px;
   font-size: 30px;
@@ -748,20 +737,59 @@ watch(() => webStore.dProfile, async (pList) => {
 }
 
 .system-info {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 5px 10px 5px 15px;
+  color: var(--text-color);
+}
+
+.profile-title {
+  font-size: 15px;
+  font-weight: 600;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  text-align: left;
-  font-size: 14px;
-  padding: 5px 10px 5px 15px;
+}
+
+.profile-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.profile-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background-color: var(--sub-card-bg);
+  border: 1px solid var(--sub-card-border);
+}
+
+.profile-stat-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--placeholder-color);
+  font-size: 12px;
+}
+
+.profile-stat-value {
   color: var(--text-color);
+  font-weight: 600;
+  font-size: 14px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .bottom-row {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  margin-top: 5px;
+  margin-top: 10px;
   margin-bottom: 4px;
   color: var(--text-color);
 }

--- a/src/views/Profiles.vue
+++ b/src/views/Profiles.vue
@@ -29,11 +29,17 @@ const formatBytes = (value: unknown) => {
   if (!hasUsageValue(value)) {
     return ''
   }
-  const number = typeof value === 'number' ? value : Number(value)
-  if (!Number.isFinite(number)) {
-    return ''
+
+  if (typeof value === 'number') {
+    return prettyBytes(value)
   }
-  return prettyBytes(number)
+
+  const numeric = Number(value)
+  if (Number.isFinite(numeric)) {
+    return prettyBytes(numeric)
+  }
+
+  return String(value)
 }
 
 const formatDate = (value: unknown) => {
@@ -51,7 +57,7 @@ const formatDate = (value: unknown) => {
 
   const date = new Date(value as any)
   if (Number.isNaN(date.getTime())) {
-    return `${value}`
+    return String(value)
   }
 
   const day = String(date.getDate()).padStart(2, '0')

--- a/src/views/Profiles.vue
+++ b/src/views/Profiles.vue
@@ -824,7 +824,7 @@ watch(() => webStore.dProfile, async (pList) => {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  margin-top: 6px;
+  margin-top: 0;
   margin-bottom: 4px;
   color: var(--text-color);
 }

--- a/src/views/Profiles.vue
+++ b/src/views/Profiles.vue
@@ -25,6 +25,12 @@ const webStore = useWebStore();
 
 const hasUsageValue = (value: unknown) => value !== undefined && value !== null && value !== ''
 
+const hasAnyStats = (profile: any) =>
+  hasUsageValue(profile?.available) ||
+  hasUsageValue(profile?.used) ||
+  hasUsageValue(profile?.expire) ||
+  hasUsageValue(profile?.update)
+
 const formatBytes = (value: unknown) => {
   if (!hasUsageValue(value)) {
     return ''
@@ -32,6 +38,10 @@ const formatBytes = (value: unknown) => {
 
   if (typeof value === 'number') {
     return prettyBytes(value)
+  }
+
+  if (typeof value === 'bigint') {
+    return prettyBytes(Number(value))
   }
 
   const numeric = Number(value)
@@ -65,6 +75,48 @@ const formatDate = (value: unknown) => {
   const year = date.getFullYear()
 
   return `${day}.${month}.${year}`
+}
+
+const getProfileStats = (profile: any) => {
+  const stats: Array<{key: string; icon: string; label: string; value: string}> = []
+
+  if (hasUsageValue(profile?.available)) {
+    stats.push({
+      key: 'available',
+      icon: 'icon-mdi-database-check',
+      label: t('profiles.available'),
+      value: formatBytes(profile.available)
+    })
+  }
+
+  if (hasUsageValue(profile?.used)) {
+    stats.push({
+      key: 'used',
+      icon: 'icon-mdi-arrow-up-bold-box-outline',
+      label: t('profiles.use'),
+      value: formatBytes(profile.used)
+    })
+  }
+
+  if (hasUsageValue(profile?.expire)) {
+    stats.push({
+      key: 'expire',
+      icon: 'icon-mdi-timer-outline',
+      label: t('profiles.expire'),
+      value: formatDate(profile.expire)
+    })
+  }
+
+  if (hasUsageValue(profile?.update)) {
+    stats.push({
+      key: 'update',
+      icon: 'icon-mdi-update',
+      label: t('profiles.update'),
+      value: formatDate(profile.update)
+    })
+  }
+
+  return stats
 }
 
 // 头部几个按钮操作
@@ -495,41 +547,27 @@ watch(() => webStore.dProfile, async (pList) => {
                     </el-icon>
                   </el-tooltip>
                 </div>
-                <div class="profile-body">
+                <div class="profile-content">
                   <div
-                      v-if="hasUsageValue(data.available) || hasUsageValue(data.used) || hasUsageValue(data.expire) || hasUsageValue(data.update)"
+                      v-if="hasAnyStats(data)"
                       class="profile-stats"
                   >
-                    <div class="profile-stat" v-if="hasUsageValue(data.available)">
+                    <div
+                        v-for="stat in getProfileStats(data)"
+                        :key="stat.key"
+                        class="profile-stat"
+                    >
                       <el-icon class="profile-stat-icon">
-                        <icon-mdi-database-check/>
+                        <component :is="stat.icon"/>
                       </el-icon>
-                      <span class="profile-stat-label">{{ $t('profiles.available') }}</span>
-                      <span class="profile-stat-value">{{ formatBytes(data.available) }}</span>
-                    </div>
-                    <div class="profile-stat" v-if="hasUsageValue(data.used)">
-                      <el-icon class="profile-stat-icon">
-                        <icon-mdi-arrow-up-bold-box-outline/>
-                      </el-icon>
-                      <span class="profile-stat-label">{{ $t('profiles.use') }}</span>
-                      <span class="profile-stat-value">{{ formatBytes(data.used) }}</span>
-                    </div>
-                    <div class="profile-stat" v-if="hasUsageValue(data.expire)">
-                      <el-icon class="profile-stat-icon">
-                        <icon-mdi-timer-outline/>
-                      </el-icon>
-                      <span class="profile-stat-label">{{ $t('profiles.expire') }}</span>
-                      <span class="profile-stat-value">{{ formatDate(data.expire) }}</span>
-                    </div>
-                    <div class="profile-stat" v-if="hasUsageValue(data.update)">
-                      <el-icon class="profile-stat-icon">
-                        <icon-mdi-update/>
-                      </el-icon>
-                      <span class="profile-stat-label">{{ $t('profiles.update') }}</span>
-                      <span class="profile-stat-value">{{ formatDate(data.update) }}</span>
+                      <span class="profile-stat-label">{{ stat.label }}</span>
+                      <span class="profile-stat-value">{{ stat.value }}</span>
                     </div>
                   </div>
-                  <div class="profile-actions">
+                  <div
+                      class="profile-actions"
+                      :class="{'profile-actions--compact': hasAnyStats(data)}"
+                  >
                     <el-tooltip
                         v-if="data.support"
                         :content="$t('profiles.support')"
@@ -790,16 +828,17 @@ watch(() => webStore.dProfile, async (pList) => {
   cursor: pointer;
 }
 
-.profile-body {
+.profile-content {
   display: flex;
   flex-direction: column;
-  gap: 0;
+  gap: 6px;
+  flex: 1;
 }
 
 .profile-stats {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 4px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .profile-stat {
@@ -833,9 +872,13 @@ watch(() => webStore.dProfile, async (pList) => {
   justify-content: flex-end;
   align-items: center;
   gap: 8px;
-  margin-top: 0;
+  margin-top: 8px;
   padding-top: 0;
   color: var(--text-color);
+}
+
+.profile-actions--compact {
+  margin-top: 0;
 }
 
 

--- a/src/views/Profiles.vue
+++ b/src/views/Profiles.vue
@@ -530,13 +530,12 @@ watch(() => webStore.dProfile, async (pList) => {
                   </div>
                 </div>
               </div>
-            </div>
-            <div class="bottom-row">
-              <el-tooltip
-                  v-if="data.support"
-                  :content="$t('profiles.support')"
-                  placement="top">
-                <el-icon
+              <div class="bottom-row">
+                <el-tooltip
+                    v-if="data.support"
+                    :content="$t('profiles.support')"
+                    placement="top">
+                  <el-icon
                     class="ops"
                     @click.stop="goSupport(data)"
                     size="20">
@@ -782,11 +781,10 @@ watch(() => webStore.dProfile, async (pList) => {
 }
 
 .system-info {
-  flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
-  padding: 5px 10px 0 15px;
+  gap: 8px;
+  padding: 5px 10px 5px 15px;
   color: var(--text-color);
 }
 
@@ -825,7 +823,6 @@ watch(() => webStore.dProfile, async (pList) => {
   justify-content: flex-end;
   gap: 8px;
   margin-top: 0;
-  margin-bottom: 4px;
   color: var(--text-color);
 }
 


### PR DESCRIPTION
## Summary
- remove the Profiles header state and add helpers for validating usage data and formatting byte values
- redesign the profile card content to show a titled usage grid with mdi icons that only renders populated statistics
- refresh the scoped styles to support the new layout and ensure empty stats do not leave gaps

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc05a02ddc832cb5cbcb9756e1b43f