### PR TITLE
Enhance profile cards with inline statistics

### DIFF
--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -67,6 +67,13 @@ home:
   download: Download
   upload: Upload
   memory: Memory
+  profile:
+    title: Current profile
+    name: Profile name
+    stats: Statistics
+    support: Support
+    subscription: Subscription
+    empty: No profile selected
   web:
     title: Website Testing
     edit: Website Title

--- a/src/locales/ru.yaml
+++ b/src/locales/ru.yaml
@@ -67,6 +67,13 @@ home:
   download: Загрузка
   upload: Отправка
   memory: Память
+  profile:
+    title: Текущий профиль
+    name: Имя профиля
+    stats: Статистика
+    support: Поддержка
+    subscription: Подписка
+    empty: Профиль не выбран
   web:
     title: Тестирование сайта
     edit: Название сайта

--- a/src/locales/zh.yaml
+++ b/src/locales/zh.yaml
@@ -67,6 +67,13 @@ home:
   download: 下载
   upload: 上传
   memory: 内存
+  profile:
+    title: 当前订阅
+    name: 配置名称
+    stats: 统计信息
+    support: 支持页面
+    subscription: 订阅页面
+    empty: 暂无选中的配置
   web:
     title: 网站测试
     edit: 网站标题

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,15 +1,390 @@
 <script setup lang="ts">
+import {computed, getCurrentInstance, onMounted, ref, watch} from "vue";
+import {useI18n} from "vue-i18n";
+import createApi from "@/api";
+import {useWebStore} from "@/store/webStore";
+import {prettyBytes} from "@/util/format";
+import {Browser} from "@/runtime";
+
+const {proxy} = getCurrentInstance()!;
+const api = createApi(proxy);
+
+const {t} = useI18n();
+const webStore = useWebStore();
+
+const currentProfile = ref<Record<string, any> | null>(null);
+
+const missingValue = "—";
+
+const profileName = computed(() => {
+  if (!currentProfile.value) {
+    return "";
+  }
+
+  return currentProfile.value.title || currentProfile.value.name || "";
+});
+
+const profileStats = computed(() => {
+  if (!currentProfile.value) {
+    return [] as { key: string; icon: string; label: string; value: string }[];
+  }
+
+  const profile = currentProfile.value;
+
+  const stats = [
+    {
+      key: "used",
+      icon: "icon-mdi-chart-timeline-variant",
+      label: t("profiles.use"),
+      value: formatTrafficValue(profile.used)
+    },
+    {
+      key: "available",
+      icon: "icon-mdi-database-check",
+      label: t("profiles.available"),
+      value: formatTrafficValue(profile.available)
+    },
+    {
+      key: "expire",
+      icon: "icon-mdi-calendar-alert",
+      label: t("profiles.expire"),
+      value: formatDateValue(profile.expire)
+    },
+    {
+      key: "update",
+      icon: "icon-mdi-update",
+      label: t("profiles.update"),
+      value: formatDateValue(profile.update)
+    }
+  ];
+
+  return stats.map(stat => ({
+    ...stat,
+    value: stat.value || missingValue
+  }));
+});
+
+const supportUrl = computed(() => currentProfile.value?.support ?? "");
+const subscriptionUrl = computed(() => currentProfile.value?.home ?? "");
+
+function hasValue(value: any) {
+  return value !== undefined && value !== null && value !== "";
+}
+
+function formatTrafficValue(value: any) {
+  if (!hasValue(value)) {
+    return "";
+  }
+
+  const num = Number(value);
+  if (Number.isFinite(num)) {
+    return prettyBytes(num);
+  }
+
+  return String(value);
+}
+
+function formatDateValue(value: any) {
+  if (!hasValue(value)) {
+    return "";
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    const match = trimmed.match(/^(\d{4})[-/.](\d{2})[-/.](\d{2})$/);
+    if (match) {
+      return `${match[3]}.${match[2]}.${match[1]}`;
+    }
+
+    const parsed = Date.parse(trimmed);
+    if (!Number.isNaN(parsed)) {
+      const date = new Date(parsed);
+      const day = String(date.getDate()).padStart(2, "0");
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const year = date.getFullYear();
+      return `${day}.${month}.${year}`;
+    }
+
+    return trimmed;
+  }
+
+  if (typeof value === "number") {
+    const timestamp = value > 1e12 ? value : value * 1000;
+    const date = new Date(timestamp);
+    if (!Number.isNaN(date.getTime())) {
+      const day = String(date.getDate()).padStart(2, "0");
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const year = date.getFullYear();
+      return `${day}.${month}.${year}`;
+    }
+  }
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    const day = String(value.getDate()).padStart(2, "0");
+    const month = String(value.getMonth() + 1).padStart(2, "0");
+    const year = value.getFullYear();
+    return `${day}.${month}.${year}`;
+  }
+
+  return String(value);
+}
+
+async function loadSelectedProfile() {
+  try {
+    const list = await api.getProfileList();
+    if (Array.isArray(list)) {
+      const selected = list.find((item: any) => item.selected);
+      currentProfile.value = selected ?? null;
+    } else {
+      currentProfile.value = null;
+    }
+  } catch (e) {
+    currentProfile.value = null;
+  }
+}
+
+function openSupport() {
+  if (supportUrl.value) {
+    Browser.OpenURL(supportUrl.value);
+  }
+}
+
+function openSubscription() {
+  if (subscriptionUrl.value) {
+    Browser.OpenURL(subscriptionUrl.value);
+  }
+}
+
+watch(
+    () => webStore.fProfile,
+    (data: any) => {
+      if (data && Object.keys(data).length) {
+        currentProfile.value = {...data};
+      } else {
+        currentProfile.value = null;
+      }
+    },
+    {deep: true}
+);
+
+onMounted(async () => {
+  if (webStore.fProfile && Object.keys(webStore.fProfile).length) {
+    currentProfile.value = {...webStore.fProfile};
+    return;
+  }
+
+  await loadSelectedProfile();
+});
 </script>
 
 <template>
   <MyLayout>
     <template #bottom>
-      <MyChart></MyChart>
-      <MyTest></MyTest>
-      <MyIp></MyIp>
+      <div class="home-content">
+        <MyChart class="home-row-chart"></MyChart>
+        <div class="home-second-row">
+          <section class="profile-card">
+            <div class="profile-card-header">
+              <h2 class="profile-card-title">
+                {{ $t('home.profile.title') }}
+              </h2>
+            </div>
+            <div v-if="currentProfile" class="profile-card-body">
+              <div class="profile-name-block">
+                <span class="profile-label">{{ $t('home.profile.name') }}</span>
+                <div class="profile-name" :title="profileName">
+                  {{ profileName || missingValue }}
+                </div>
+              </div>
+              <div class="profile-stats-block">
+                <span class="profile-label">{{ $t('home.profile.stats') }}</span>
+                <div class="profile-stats">
+                  <div class="profile-stat-row" v-for="stat in profileStats" :key="stat.key">
+                    <el-icon size="18" class="profile-stat-icon">
+                      <component :is="stat.icon"/>
+                    </el-icon>
+                    <span class="profile-stat-label">{{ stat.label }}</span>
+                    <span class="profile-stat-value">{{ stat.value }}</span>
+                  </div>
+                </div>
+              </div>
+              <div class="profile-actions" v-if="supportUrl || subscriptionUrl">
+                <el-button
+                    v-if="supportUrl"
+                    size="small"
+                    type="primary"
+                    plain
+                    @click="openSupport"
+                >
+                  <el-icon class="profile-action-icon">
+                    <icon-mdi-face-agent/>
+                  </el-icon>
+                  {{ $t('home.profile.support') }}
+                </el-button>
+                <el-button
+                    v-if="subscriptionUrl"
+                    size="small"
+                    type="primary"
+                    plain
+                    @click="openSubscription"
+                >
+                  <el-icon class="profile-action-icon">
+                    <icon-mdi-home-import-outline/>
+                  </el-icon>
+                  {{ $t('home.profile.subscription') }}
+                </el-button>
+              </div>
+            </div>
+            <div v-else class="profile-empty">
+              {{ $t('home.profile.empty') }}
+            </div>
+          </section>
+          <div class="test-wrapper">
+            <MyTest></MyTest>
+          </div>
+        </div>
+        <MyIp class="home-row-ip"></MyIp>
+      </div>
     </template>
   </MyLayout>
 </template>
 
 <style scoped>
+.home-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding-right: 18px;
+}
+
+.home-row-chart :deep(.spark) {
+  width: 100%;
+}
+
+.home-second-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 20px;
+  align-items: stretch;
+}
+
+.profile-card {
+  border: 2px solid var(--sub-card-border);
+  background: var(--sub-card-bg);
+  border-radius: 8px;
+  color: var(--text-color);
+  box-shadow: var(--left-nav-shadow);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.profile-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.profile-card-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.profile-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.profile-name-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.profile-label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-color);
+  opacity: 0.7;
+}
+
+.profile-name {
+  font-size: 18px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.profile-stats-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.profile-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.profile-stat-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.profile-stat-icon {
+  color: var(--text-color);
+}
+
+.profile-stat-label {
+  font-size: 14px;
+}
+
+.profile-stat-value {
+  font-weight: 600;
+}
+
+.profile-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.profile-action-icon {
+  margin-right: 6px;
+}
+
+.profile-empty {
+  color: var(--text-color);
+  font-size: 14px;
+  opacity: 0.7;
+}
+
+.test-wrapper {
+  min-width: 0;
+  display: flex;
+}
+
+.test-wrapper :deep(.t-card) {
+  margin-left: 0 !important;
+  margin-top: 0;
+  width: 100% !important;
+  flex: 1;
+  height: 100%;
+}
+
+.test-wrapper :deep(.t-card hr) {
+  margin: 10px 0;
+}
+
+.home-row-ip :deep(.spark) {
+  width: 100%;
+}
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -267,10 +267,12 @@ onMounted(async () => {
 
 .home-second-row {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 20px;
   align-items: stretch;
   width: 100%;
+  max-width: 95%;
+  margin: 0 auto;
 }
 
 .profile-card {
@@ -378,5 +380,11 @@ onMounted(async () => {
 
 .home-row-ip :deep(.spark) {
   width: 100%;
+}
+
+@media (max-width: 900px) {
+  .home-second-row {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -58,10 +58,21 @@ const profileStats = computed(() => {
     }
   ];
 
-  return stats.map(stat => ({
-    ...stat,
-    value: stat.value || missingValue
-  }));
+  return stats.reduce((acc, stat) => {
+    const rawValue = stat.value;
+    const normalized = typeof rawValue === "string" ? rawValue.trim() : rawValue;
+
+    if (!normalized) {
+      return acc;
+    }
+
+    acc.push({
+      ...stat,
+      value: typeof normalized === "string" ? normalized : String(normalized)
+    });
+
+    return acc;
+  }, [] as { key: string; icon: string; label: string; value: string }[]);
 });
 
 const supportUrl = computed(() => currentProfile.value?.support ?? "");
@@ -185,57 +196,50 @@ onMounted(async () => {
         <div class="home-second-row">
           <section class="profile-card">
             <div class="profile-card-header">
-              <h2 class="profile-card-title">
-                {{ $t('home.profile.title') }}
-              </h2>
-            </div>
-            <div v-if="currentProfile" class="profile-card-body">
-              <div class="profile-name-block">
-                <span class="profile-label">{{ $t('home.profile.name') }}</span>
-                <div class="profile-name" :title="profileName">
-                  {{ profileName || missingValue }}
-                </div>
-              </div>
-              <div class="profile-stats-block">
-                <span class="profile-label">{{ $t('home.profile.stats') }}</span>
-                <div class="profile-stats">
-                  <div class="profile-stat-row" v-for="stat in profileStats" :key="stat.key">
-                    <el-icon size="18" class="profile-stat-icon">
-                      <component :is="stat.icon"/>
-                    </el-icon>
-                    <span class="profile-stat-label">{{ stat.label }}</span>
-                    <span class="profile-stat-value">{{ stat.value }}</span>
-                  </div>
-                </div>
-              </div>
-              <div class="profile-actions" v-if="supportUrl || subscriptionUrl">
-                <el-button
+              <span class="profile-name" :title="currentProfile ? profileName : ''">
+                {{ currentProfile ? (profileName || missingValue) : missingValue }}
+              </span>
+              <div class="profile-links" v-if="supportUrl || subscriptionUrl">
+                <el-tooltip
                     v-if="supportUrl"
-                    size="small"
-                    type="primary"
-                    plain
-                    @click="openSupport"
+                    :content="$t('home.profile.support')"
+                    placement="top"
                 >
-                  <el-icon class="profile-action-icon">
+                  <el-icon
+                      size="20"
+                      class="profile-link"
+                      @click="openSupport"
+                  >
                     <icon-mdi-face-agent/>
                   </el-icon>
-                  {{ $t('home.profile.support') }}
-                </el-button>
-                <el-button
+                </el-tooltip>
+                <el-tooltip
                     v-if="subscriptionUrl"
-                    size="small"
-                    type="primary"
-                    plain
-                    @click="openSubscription"
+                    :content="$t('home.profile.subscription')"
+                    placement="top"
                 >
-                  <el-icon class="profile-action-icon">
+                  <el-icon
+                      size="20"
+                      class="profile-link"
+                      @click="openSubscription"
+                  >
                     <icon-mdi-home-import-outline/>
                   </el-icon>
-                  {{ $t('home.profile.subscription') }}
-                </el-button>
+                </el-tooltip>
               </div>
             </div>
-            <div v-else class="profile-empty">
+            <hr class="profile-divider"/>
+            <div v-if="currentProfile && profileStats.length" class="profile-stats">
+              <div class="profile-stat-row" v-for="stat in profileStats" :key="stat.key">
+                <el-icon size="18" class="profile-stat-icon">
+                  <component :is="stat.icon"/>
+                </el-icon>
+                <span class="profile-stat-label">{{ stat.label }}</span>
+                <span class="profile-stat-separator">-</span>
+                <span class="profile-stat-value">{{ stat.value }}</span>
+              </div>
+            </div>
+            <div v-else-if="!currentProfile" class="profile-empty">
               {{ $t('home.profile.empty') }}
             </div>
           </section>
@@ -269,47 +273,21 @@ onMounted(async () => {
 }
 
 .profile-card {
-  border: 2px solid var(--sub-card-border);
-  background: var(--sub-card-bg);
+  padding: 10px;
   border-radius: 8px;
+  text-align: left;
+  box-shadow: var(--right-box-shadow);
+  background: var(--sub-card-bg);
   color: var(--text-color);
-  box-shadow: var(--left-nav-shadow);
-  padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
 }
 
 .profile-card-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-}
-
-.profile-card-title {
-  font-size: 18px;
-  font-weight: 600;
-  margin: 0;
-}
-
-.profile-card-body {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-}
-
-.profile-name-block {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.profile-label {
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--text-color);
-  opacity: 0.7;
+  gap: 12px;
 }
 
 .profile-name {
@@ -318,25 +296,43 @@ onMounted(async () => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  flex: 1 1 auto;
 }
 
-.profile-stats-block {
+.profile-links {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
+  align-items: center;
+  gap: 10px;
+}
+
+.profile-link {
+  color: var(--text-color);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.profile-link:hover {
+  color: var(--hr-color);
+}
+
+.profile-divider {
+  border: none;
+  height: 1px;
+  background-color: var(--hr-color);
+  margin: 10px 0;
 }
 
 .profile-stats {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
 }
 
 .profile-stat-row {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
+  display: flex;
   align-items: center;
   gap: 8px;
+  font-size: 14px;
 }
 
 .profile-stat-icon {
@@ -344,21 +340,15 @@ onMounted(async () => {
 }
 
 .profile-stat-label {
-  font-size: 14px;
+  font-weight: 500;
+}
+
+.profile-stat-separator {
+  opacity: 0.6;
 }
 
 .profile-stat-value {
   font-weight: 600;
-}
-
-.profile-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.profile-action-icon {
-  margin-right: 6px;
 }
 
 .profile-empty {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -24,55 +24,15 @@ const profileName = computed(() => {
   return currentProfile.value.title || currentProfile.value.name || "";
 });
 
-const profileStats = computed(() => {
+const hasProfileStats = computed(() => {
   if (!currentProfile.value) {
-    return [] as { key: string; icon: string; label: string; value: string }[];
+    return false;
   }
 
   const profile = currentProfile.value;
-
-  const stats = [
-    {
-      key: "used",
-      icon: "icon-mdi-chart-timeline-variant",
-      label: t("profiles.use"),
-      value: formatTrafficValue(profile.used)
-    },
-    {
-      key: "available",
-      icon: "icon-mdi-database-check",
-      label: t("profiles.available"),
-      value: formatTrafficValue(profile.available)
-    },
-    {
-      key: "expire",
-      icon: "icon-mdi-calendar-alert",
-      label: t("profiles.expire"),
-      value: formatDateValue(profile.expire)
-    },
-    {
-      key: "update",
-      icon: "icon-mdi-update",
-      label: t("profiles.update"),
-      value: formatDateValue(profile.update)
-    }
-  ];
-
-  return stats.reduce((acc, stat) => {
-    const rawValue = stat.value;
-    const normalized = typeof rawValue === "string" ? rawValue.trim() : rawValue;
-
-    if (!normalized) {
-      return acc;
-    }
-
-    acc.push({
-      ...stat,
-      value: typeof normalized === "string" ? normalized : String(normalized)
-    });
-
-    return acc;
-  }, [] as { key: string; icon: string; label: string; value: string }[]);
+  return [profile.used, profile.available, profile.expire, profile.update].some((item) =>
+    hasValue(item)
+  );
 });
 
 const supportUrl = computed(() => currentProfile.value?.support ?? "");
@@ -202,7 +162,7 @@ onMounted(async () => {
               <div class="profile-links" v-if="supportUrl || subscriptionUrl">
                 <el-tooltip
                     v-if="supportUrl"
-                    :content="$t('home.profile.support')"
+                    :content="$t('profiles.support')"
                     placement="top"
                 >
                   <el-icon
@@ -215,7 +175,7 @@ onMounted(async () => {
                 </el-tooltip>
                 <el-tooltip
                     v-if="subscriptionUrl"
-                    :content="$t('home.profile.subscription')"
+                    :content="$t('profiles.home')"
                     placement="top"
                 >
                   <el-icon
@@ -229,16 +189,39 @@ onMounted(async () => {
               </div>
             </div>
             <hr class="profile-divider"/>
-            <div v-if="currentProfile && profileStats.length" class="profile-stats">
-              <div class="profile-stat-row" v-for="stat in profileStats" :key="stat.key">
-                <el-icon size="18" class="profile-stat-icon">
-                  <component :is="stat.icon"/>
-                </el-icon>
-                <span class="profile-stat-label">{{ stat.label }}</span>
-                <span class="profile-stat-value">{{ stat.value }}</span>
-              </div>
+            <div v-if="currentProfile" class="profile-stats">
+              <template v-if="hasProfileStats">
+                <div class="profile-stat-row" v-if="hasValue(currentProfile.used)">
+                  <el-icon size="18" class="profile-stat-icon">
+                    <icon-mdi-chart-timeline-variant/>
+                  </el-icon>
+                  <span class="profile-stat-label">{{ $t('profiles.use') }}</span>
+                  <span class="profile-stat-value">{{ formatTrafficValue(currentProfile.used) }}</span>
+                </div>
+                <div class="profile-stat-row" v-if="hasValue(currentProfile.available)">
+                  <el-icon size="18" class="profile-stat-icon">
+                    <icon-mdi-database-check/>
+                  </el-icon>
+                  <span class="profile-stat-label">{{ $t('profiles.available') }}</span>
+                  <span class="profile-stat-value">{{ formatTrafficValue(currentProfile.available) }}</span>
+                </div>
+                <div class="profile-stat-row" v-if="hasValue(currentProfile.expire)">
+                  <el-icon size="18" class="profile-stat-icon">
+                    <icon-mdi-calendar-alert/>
+                  </el-icon>
+                  <span class="profile-stat-label">{{ $t('profiles.expire') }}</span>
+                  <span class="profile-stat-value">{{ formatDateValue(currentProfile.expire) }}</span>
+                </div>
+                <div class="profile-stat-row" v-if="hasValue(currentProfile.update)">
+                  <el-icon size="18" class="profile-stat-icon">
+                    <icon-mdi-update/>
+                  </el-icon>
+                  <span class="profile-stat-label">{{ $t('profiles.update') }}</span>
+                  <span class="profile-stat-value">{{ formatDateValue(currentProfile.update) }}</span>
+                </div>
+              </template>
             </div>
-            <div v-else-if="!currentProfile" class="profile-empty">
+            <div v-else class="profile-empty">
               {{ $t('home.profile.empty') }}
             </div>
           </section>
@@ -269,6 +252,8 @@ onMounted(async () => {
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 20px;
   align-items: stretch;
+  max-width: 95%;
+  margin-left: 2px;
 }
 
 .profile-card {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -235,7 +235,6 @@ onMounted(async () => {
                   <component :is="stat.icon"/>
                 </el-icon>
                 <span class="profile-stat-label">{{ stat.label }}</span>
-                <span class="profile-stat-separator">-</span>
                 <span class="profile-stat-value">{{ stat.value }}</span>
               </div>
             </div>
@@ -277,7 +276,7 @@ onMounted(async () => {
   border-radius: 8px;
   text-align: left;
   box-shadow: var(--right-box-shadow);
-  background: var(--sub-card-bg);
+  background: transparent;
   color: var(--text-color);
   display: flex;
   flex-direction: column;
@@ -325,7 +324,8 @@ onMounted(async () => {
 .profile-stats {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
+  min-height: 120px;
 }
 
 .profile-stat-row {
@@ -340,15 +340,15 @@ onMounted(async () => {
 }
 
 .profile-stat-label {
+  flex: 1;
   font-weight: 500;
-}
-
-.profile-stat-separator {
-  opacity: 0.6;
+  min-width: 0;
 }
 
 .profile-stat-value {
   font-weight: 600;
+  text-align: right;
+  white-space: nowrap;
 }
 
 .profile-empty {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -35,8 +35,16 @@ const hasProfileStats = computed(() => {
   );
 });
 
-const supportUrl = computed(() => currentProfile.value?.support ?? "");
-const subscriptionUrl = computed(() => currentProfile.value?.home ?? "");
+function normalizeUrl(raw: unknown) {
+  if (typeof raw !== "string") {
+    return "";
+  }
+
+  return raw.trim();
+}
+
+const supportUrl = computed(() => normalizeUrl(currentProfile.value?.support));
+const subscriptionUrl = computed(() => normalizeUrl(currentProfile.value?.home));
 
 function hasValue(value: any) {
   return value !== undefined && value !== null && value !== "";
@@ -114,16 +122,26 @@ async function loadSelectedProfile() {
   }
 }
 
-function openSupport() {
-  if (supportUrl.value) {
-    Browser.OpenURL(supportUrl.value);
+function openExternal(url: string) {
+  if (!url) {
+    return;
+  }
+
+  try {
+    Browser.OpenURL(url);
+  } catch (error) {
+    if (typeof window !== "undefined") {
+      window.open(url, "_blank", "noopener");
+    }
   }
 }
 
+function openSupport() {
+  openExternal(supportUrl.value);
+}
+
 function openSubscription() {
-  if (subscriptionUrl.value) {
-    Browser.OpenURL(subscriptionUrl.value);
-  }
+  openExternal(subscriptionUrl.value);
 }
 
 watch(

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -270,8 +270,7 @@ onMounted(async () => {
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 20px;
   align-items: stretch;
-  max-width: 95%;
-  margin-left: 2px;
+  width: 100%;
 }
 
 .profile-card {

--- a/src/views/Profiles.vue
+++ b/src/views/Profiles.vue
@@ -800,6 +800,7 @@ watch(() => webStore.dProfile, async (pList) => {
   padding: 6px 6px 0 6px;
   font-size: 13px;
   color: var(--text-color);
+  min-height: 90px;
 }
 
 .stat-row {
@@ -810,7 +811,7 @@ watch(() => webStore.dProfile, async (pList) => {
 
 .stat-label {
   flex: 1;
-  color: var(--top-hr-color);
+  color: var(--text-color);
 }
 
 .stat-value {

--- a/src/views/Profiles.vue
+++ b/src/views/Profiles.vue
@@ -234,12 +234,31 @@ async function refresh(data: any) {
 
 // 几个按钮操作
 // 到主页
+function openExternalLink(raw: any) {
+  if (typeof raw !== 'string') {
+    return
+  }
+
+  const url = raw.trim()
+  if (!url) {
+    return
+  }
+
+  try {
+    Browser.OpenURL(url)
+  } catch (error) {
+    if (typeof window !== 'undefined') {
+      window.open(url, '_blank', 'noopener')
+    }
+  }
+}
+
 function goHome(data: any) {
-  Browser.OpenURL(data.home)
+  openExternalLink(data.home)
 }
 
 function goSupport(data: any) {
-  Browser.OpenURL(data.support)
+  openExternalLink(data.support)
 }
 
 // 修改配置

--- a/src/views/Profiles.vue
+++ b/src/views/Profiles.vue
@@ -68,35 +68,64 @@ function openFile() {
   webStore.dnd = true
 }
 
-// 头部显示
-const headerShow = reactive({
-  available: '',
-  used: '',
-  expire: '',
-  update: '',
-})
+function hasValue(value: any) {
+  return value !== undefined && value !== null && value !== ''
+}
 
-function setHeaderShow(item: any) {
-  if (item['available']) {
-    headerShow.available = prettyBytes(item['available'])
-  } else {
-    headerShow.available = ''
+function formatTrafficValue(value: any) {
+  if (!hasValue(value)) {
+    return ''
   }
-  if (item['used']) {
-    headerShow.used = prettyBytes(item['used'])
-  } else {
-    headerShow.used = ''
+  const num = Number(value)
+  if (Number.isFinite(num)) {
+    return prettyBytes(num)
   }
-  if (item['expire']) {
-    headerShow.expire = item['expire']
-  } else {
-    headerShow.expire = ''
+  return String(value)
+}
+
+function formatDateValue(value: any) {
+  if (!hasValue(value)) {
+    return ''
   }
-  if (item['update']) {
-    headerShow.update = item['update']
-  } else {
-    headerShow.update = ''
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    const match = trimmed.match(/^(\d{4})[-/.](\d{2})[-/.](\d{2})$/)
+    if (match) {
+      return `${match[3]}.${match[2]}.${match[1]}`
+    }
+
+    const parsed = Date.parse(trimmed)
+    if (!Number.isNaN(parsed)) {
+      const date = new Date(parsed)
+      const day = String(date.getDate()).padStart(2, '0')
+      const month = String(date.getMonth() + 1).padStart(2, '0')
+      const year = date.getFullYear()
+      return `${day}.${month}.${year}`
+    }
+
+    return trimmed
   }
+
+  if (typeof value === 'number') {
+    const timestamp = value > 1e12 ? value : value * 1000
+    const date = new Date(timestamp)
+    if (!Number.isNaN(date.getTime())) {
+      const day = String(date.getDate()).padStart(2, '0')
+      const month = String(date.getMonth() + 1).padStart(2, '0')
+      const year = date.getFullYear()
+      return `${day}.${month}.${year}`
+    }
+  }
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    const day = String(value.getDate()).padStart(2, '0')
+    const month = String(value.getMonth() + 1).padStart(2, '0')
+    const year = value.getFullYear()
+    return `${day}.${month}.${year}`
+  }
+
+  return String(value)
 }
 
 // 列表显示
@@ -110,9 +139,6 @@ async function getProfileList() {
   if (list && list.length != 0) {
     list.forEach(item => {
       profiles.push(item)
-      if (item['selected']) {
-        setHeaderShow(item)
-      }
     })
 
     Events.Emit({
@@ -153,7 +179,6 @@ async function switchProfile(data: any) {
         }
       }
       data['selected'] = true
-      setHeaderShow(data)
 
       api.getRuleNum().then((res) => {
         menuStore.setRuleNum(res);
@@ -189,7 +214,6 @@ watch(() => webStore.fProfile, async (data: any) => {
   }
 
   data['selected'] = true
-  setHeaderShow(data)
 })
 
 
@@ -198,9 +222,6 @@ async function refresh(data: any) {
   await pLoad(t('profiles.refresh.ing'), async () => {
     try {
       const re = await api.refreshProfile(data)
-      if (data['selected']) {
-        setHeaderShow(re)
-      }
       Object.assign(data, re);
       pSuccess(t('profiles.refresh.success'))
     } catch (e) {
@@ -452,23 +473,6 @@ watch(() => webStore.dProfile, async (pList) => {
         </div>
       </el-space>
 
-      <div class="sub-title">
-        <template v-if="headerShow.available">
-          <span>{{ $t('profiles.available') }} {{ headerShow.available }}</span>
-          <el-divider direction="vertical" border-style="dashed"/>
-        </template>
-        <template v-if="headerShow.used">
-          <span>{{ $t('profiles.use') }} {{ headerShow.used }}</span>
-          <el-divider direction="vertical" border-style="dashed"/>
-        </template>
-        <template v-if="headerShow.expire">
-          <span>{{ $t('profiles.expire') }} {{ headerShow.expire }}</span>
-          <el-divider direction="vertical" border-style="dashed"/>
-        </template>
-        <template v-if="headerShow.update">
-          <span>{{ $t('profiles.update') }} {{ headerShow.update }}</span>
-        </template>
-      </div>
     </template>
 
     <template #bottom>
@@ -484,7 +488,7 @@ watch(() => webStore.dProfile, async (pList) => {
               :class="data.selected?'sub-card sub-card-select':'sub-card'"
               @click="switchProfile(data)"
           >
-            <div class="row">
+            <div class="row card-header">
               <el-icon
                   @mouseenter.stop="mouseEnter"
                   @mouseleave.stop="mouseLeave"
@@ -492,24 +496,51 @@ watch(() => webStore.dProfile, async (pList) => {
                   class="drag">
                 <icon-mdi-drag/>
               </el-icon>
-              <el-tooltip
-                  v-if="data.type == 1"
-                  :content="$t('refresh')"
-                  placement="top">
-                <el-icon size="22"
-                         class="ops"
-                         @click.stop="refresh(data)">
-                  <icon-mdi-refresh/>
-                </el-icon>
-              </el-tooltip>
-
-            </div>
-            <div
-                class="system-info"
-            >
-              <span :title="data.title">
+              <div class="profile-name" :title="data.title">
                 {{ data.title }}
-              </span>
+              </div>
+              <div class="header-action">
+                <el-tooltip
+                    v-if="data.type == 1"
+                    :content="$t('refresh')"
+                    placement="top">
+                  <el-icon size="22"
+                           class="ops"
+                           @click.stop="refresh(data)">
+                    <icon-mdi-refresh/>
+                  </el-icon>
+                </el-tooltip>
+              </div>
+            </div>
+            <div class="stats">
+              <div class="stat-row" v-if="hasValue(data.used)">
+                <el-icon size="18" class="stat-icon">
+                  <icon-mdi-chart-timeline-variant/>
+                </el-icon>
+                <span class="stat-label">{{ $t('profiles.use') }}</span>
+                <span class="stat-value">{{ formatTrafficValue(data.used) }}</span>
+              </div>
+              <div class="stat-row" v-if="hasValue(data.available)">
+                <el-icon size="18" class="stat-icon">
+                  <icon-mdi-database-check/>
+                </el-icon>
+                <span class="stat-label">{{ $t('profiles.available') }}</span>
+                <span class="stat-value">{{ formatTrafficValue(data.available) }}</span>
+              </div>
+              <div class="stat-row" v-if="hasValue(data.expire)">
+                <el-icon size="18" class="stat-icon">
+                  <icon-mdi-calendar-alert/>
+                </el-icon>
+                <span class="stat-label">{{ $t('profiles.expire') }}</span>
+                <span class="stat-value">{{ formatDateValue(data.expire) }}</span>
+              </div>
+              <div class="stat-row" v-if="hasValue(data.update)">
+                <el-icon size="18" class="stat-icon">
+                  <icon-mdi-update/>
+                </el-icon>
+                <span class="stat-label">{{ $t('profiles.update') }}</span>
+                <span class="stat-value">{{ formatDateValue(data.update) }}</span>
+              </div>
             </div>
             <div class="bottom-row">
               <el-tooltip
@@ -687,13 +718,6 @@ watch(() => webStore.dProfile, async (pList) => {
   margin-left: 10px;
 }
 
-.sub-title {
-  margin-left: 10px;
-  color: var(--top-hr-color);
-  font-size: 14px;
-  margin-top: 15px;
-}
-
 .profile-option {
   margin-left: 10px;
   font-size: 30px;
@@ -747,24 +771,61 @@ watch(() => webStore.dProfile, async (pList) => {
   cursor: pointer;
 }
 
-.system-info {
+.card-header {
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px 0 6px;
+}
+
+.profile-name {
+  flex: 1;
+  text-align: center;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  text-align: left;
-  font-size: 14px;
-  padding: 5px 10px 5px 15px;
+  font-weight: 600;
+}
+
+.header-action {
+  min-width: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.stats {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 6px 0 6px;
+  font-size: 13px;
   color: var(--text-color);
+}
+
+.stat-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.stat-label {
+  flex: 1;
+  color: var(--top-hr-color);
+}
+
+.stat-value {
+  font-weight: 500;
 }
 
 .bottom-row {
   display: flex;
   justify-content: flex-end;
   gap: 8px;
-  margin-top: 5px;
+  margin-top: 10px;
   margin-bottom: 4px;
   color: var(--text-color);
 }
-
-
+.stat-icon {
+  color: var(--text-color);
+}
 </style>


### PR DESCRIPTION
## Summary
- show each profile's usage, availability, expiry and update stats directly inside its card with mdi icons
- add helpers to format traffic totals and dates to the required 25.12.2033 style
- center the profile name between the drag and refresh buttons and refresh the card layout styles

## Testing
- npm run lint *(fails: existing repository lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4eef5230832c896540b2496f0923