### PR TITLE
Add selected profile summary to home dashboard

### DIFF
--- a/src/components/home/MyProfileCard.vue
+++ b/src/components/home/MyProfileCard.vue
@@ -1,0 +1,290 @@
+<script setup lang="ts">
+import createApi from "@/api";
+import {prettyBytes} from "@/util/format";
+import {useI18n} from "vue-i18n";
+import {Browser, Events} from "@/runtime";
+import {useWebStore} from "@/store/webStore";
+
+const {t} = useI18n();
+const {proxy} = getCurrentInstance()!;
+const api = createApi(proxy);
+const webStore = useWebStore();
+
+const currentProfile = ref<any | null>(null);
+
+function hasValue(value: any) {
+  return value !== undefined && value !== null && value !== "";
+}
+
+function formatTrafficValue(value: any) {
+  if (!hasValue(value)) {
+    return "";
+  }
+  const num = Number(value);
+  if (Number.isFinite(num)) {
+    return prettyBytes(num);
+  }
+  return String(value);
+}
+
+function formatDateValue(value: any) {
+  if (!hasValue(value)) {
+    return "";
+  }
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    const match = trimmed.match(/^(\d{4})[-/.](\d{2})[-/.](\d{2})$/);
+    if (match) {
+      return `${match[3]}.${match[2]}.${match[1]}`;
+    }
+
+    const parsed = Date.parse(trimmed);
+    if (!Number.isNaN(parsed)) {
+      const date = new Date(parsed);
+      const day = String(date.getDate()).padStart(2, "0");
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const year = date.getFullYear();
+      return `${day}.${month}.${year}`;
+    }
+
+    return trimmed;
+  }
+
+  if (typeof value === "number") {
+    const timestamp = value > 1e12 ? value : value * 1000;
+    const date = new Date(timestamp);
+    if (!Number.isNaN(date.getTime())) {
+      const day = String(date.getDate()).padStart(2, "0");
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const year = date.getFullYear();
+      return `${day}.${month}.${year}`;
+    }
+  }
+
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    const day = String(value.getDate()).padStart(2, "0");
+    const month = String(value.getMonth() + 1).padStart(2, "0");
+    const year = value.getFullYear();
+    return `${day}.${month}.${year}`;
+  }
+
+  return String(value);
+}
+
+function openExternalLink(raw: any) {
+  if (typeof raw !== "string") {
+    return;
+  }
+
+  const url = raw.trim();
+  if (!url) {
+    return;
+  }
+
+  try {
+    Browser.OpenURL(url);
+  } catch (error) {
+    if (typeof window !== "undefined") {
+      window.open(url, "_blank", "noopener");
+    }
+  }
+}
+
+function goHome(data: any) {
+  openExternalLink(data?.home);
+}
+
+function goSupport(data: any) {
+  openExternalLink(data?.support);
+}
+
+function applyProfile(data: any | null) {
+  if (!data) {
+    currentProfile.value = null;
+    return;
+  }
+
+  currentProfile.value = {...data};
+}
+
+function pickSelectedProfile(list: any[]) {
+  if (!Array.isArray(list) || list.length === 0) {
+    applyProfile(null);
+    return;
+  }
+
+  const selected = list.find(item => item?.selected);
+  applyProfile(selected ?? list[0]);
+}
+
+async function loadProfiles() {
+  try {
+    const list = await api.getProfileList();
+    pickSelectedProfile(list);
+  } catch (error) {
+    console.error("Failed to load profiles", error);
+  }
+}
+
+watch(
+    () => webStore.fProfile,
+    (data: any) => {
+      if (data && Object.keys(data).length > 0) {
+        applyProfile(data);
+      }
+    }
+);
+
+onMounted(async () => {
+  await loadProfiles();
+  Events.On("profiles", (list: any[]) => {
+    pickSelectedProfile(list);
+  });
+});
+
+const profileTitle = computed(() => {
+  if (!currentProfile.value) {
+    return "";
+  }
+  return currentProfile.value.title || currentProfile.value.name || "";
+});
+
+</script>
+
+<template>
+  <div class="profile-card" v-if="currentProfile">
+    <div class="profile-header">
+      <div class="profile-name" :title="profileTitle">
+        {{ profileTitle }}
+      </div>
+      <div class="profile-links">
+        <el-tooltip
+            v-if="currentProfile.support"
+            :content="$t('profiles.support')"
+            placement="top">
+          <el-icon
+              class="profile-link"
+              size="20"
+              @click.stop="goSupport(currentProfile)">
+            <icon-mdi-face-agent/>
+          </el-icon>
+        </el-tooltip>
+        <el-tooltip
+            v-if="currentProfile.home"
+            :content="$t('profiles.home')"
+            placement="top">
+          <el-icon
+              class="profile-link"
+              size="20"
+              @click.stop="goHome(currentProfile)">
+            <icon-mdi-home-import-outline/>
+          </el-icon>
+        </el-tooltip>
+      </div>
+    </div>
+    <div class="profile-stat" v-if="hasValue(currentProfile.used)">
+      <el-icon class="profile-stat-icon" size="18">
+        <icon-mdi-chart-timeline-variant/>
+      </el-icon>
+      <span class="profile-stat-label">{{ $t('profiles.use') }}</span>
+      <span class="profile-stat-value">{{ formatTrafficValue(currentProfile.used) }}</span>
+    </div>
+    <div class="profile-stat" v-if="hasValue(currentProfile.available)">
+      <el-icon class="profile-stat-icon" size="18">
+        <icon-mdi-database-check/>
+      </el-icon>
+      <span class="profile-stat-label">{{ $t('profiles.available') }}</span>
+      <span class="profile-stat-value">{{ formatTrafficValue(currentProfile.available) }}</span>
+    </div>
+    <div class="profile-stat" v-if="hasValue(currentProfile.expire)">
+      <el-icon class="profile-stat-icon" size="18">
+        <icon-mdi-calendar-alert/>
+      </el-icon>
+      <span class="profile-stat-label">{{ $t('profiles.expire') }}</span>
+      <span class="profile-stat-value">{{ formatDateValue(currentProfile.expire) }}</span>
+    </div>
+    <div class="profile-stat" v-if="hasValue(currentProfile.update)">
+      <el-icon class="profile-stat-icon" size="18">
+        <icon-mdi-update/>
+      </el-icon>
+      <span class="profile-stat-label">{{ $t('profiles.update') }}</span>
+      <span class="profile-stat-value">{{ formatDateValue(currentProfile.update) }}</span>
+    </div>
+  </div>
+  <div class="profile-card profile-card-empty" v-else>
+    {{ $t('home.profile.empty') }}
+  </div>
+</template>
+
+<style scoped>
+.profile-card {
+  width: 100%;
+  padding: 16px;
+  border-radius: 8px;
+  box-shadow: var(--right-box-shadow);
+  background: var(--sub-card-bg);
+  color: var(--text-color);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.profile-card-empty {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  min-height: 180px;
+  font-size: 16px;
+  display: flex;
+}
+
+.profile-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.profile-name {
+  font-size: 20px;
+  font-weight: 600;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.profile-links {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.profile-link {
+  color: var(--text-color);
+}
+
+.profile-link:hover {
+  cursor: pointer;
+  color: var(--hr-color);
+}
+
+.profile-stat {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+}
+
+.profile-stat-label {
+  flex: 1;
+}
+
+.profile-stat-value {
+  font-weight: 500;
+}
+
+.profile-stat-icon {
+  color: var(--text-color);
+}
+</style>

--- a/src/components/home/MyTest.vue
+++ b/src/components/home/MyTest.vue
@@ -157,7 +157,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <el-row class="t-card" :gutter="20" style="margin-left: 12px">
+  <el-row class="t-card" :gutter="20">
     <el-col :span="24">
       <el-row>
         {{ $t('home.web.title') }}
@@ -312,9 +312,8 @@ onMounted(async () => {
 <style scoped>
 /* 整体卡片样式 */
 .t-card {
-  width: calc(95% - 20px);
-  margin-top: 28px;
-  padding: 10px 0 10px 0;
+  width: 100%;
+  padding: 10px 0;
   border-radius: 8px;
   text-align: left;
   box-shadow: var(--right-box-shadow);

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -67,6 +67,8 @@ home:
   download: Download
   upload: Upload
   memory: Memory
+  profile:
+    empty: No profile selected
   web:
     title: Website Testing
     edit: Website Title

--- a/src/locales/ru.yaml
+++ b/src/locales/ru.yaml
@@ -67,6 +67,8 @@ home:
   download: Загрузка
   upload: Отправка
   memory: Память
+  profile:
+    empty: Профиль не выбран
   web:
     title: Тестирование сайта
     edit: Название сайта

--- a/src/locales/zh.yaml
+++ b/src/locales/zh.yaml
@@ -67,6 +67,8 @@ home:
   download: 下载
   upload: 上传
   memory: 内存
+  profile:
+    empty: 暂无选中的配置
   web:
     title: 网站测试
     edit: 网站标题

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -4,12 +4,37 @@
 <template>
   <MyLayout>
     <template #bottom>
-      <MyChart></MyChart>
-      <MyTest></MyTest>
-      <MyIp></MyIp>
+      <MyChart />
+      <div class="home-second-row">
+        <div class="home-profile">
+          <MyProfileCard />
+        </div>
+        <div class="home-test">
+          <MyTest />
+        </div>
+      </div>
+      <MyIp />
     </template>
   </MyLayout>
 </template>
 
 <style scoped>
+.home-second-row {
+  width: calc(95% - 12px);
+  margin-left: 12px;
+  margin-top: 28px;
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.home-profile {
+  flex: 1 1 320px;
+  min-width: 280px;
+}
+
+.home-test {
+  flex: 2 1 480px;
+  min-width: 320px;
+}
 </style>


### PR DESCRIPTION
## Summary
- add a current-profile summary card to the home dashboard with key statistics and quick links
- reorganize the home view second row so the profile card sits beside the website testing panel and tweak its styling
- add locale strings for the empty-profile state in English, Russian, and Chinese

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cd008aa5a4832ca304f3f6ee41f98c