### PR TITLE
Replace zip maker patch with internal implementation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,11 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64]
+    env:
+      TEAM_ID: ${{ secrets.TEAM_ID }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
+      FORCE_CODE_SIGN: 'true'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -274,6 +279,35 @@ jobs:
         run: |
           VERSION=$(git describe --tags --abbrev=0)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Configure Code Signing
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="ci-signing.keychain-db"
+          KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN"
+          CERT_PATH="$(mktemp /tmp/cert-XXXXXXXX.p12)"
+          security delete-keychain "$KEYCHAIN" >/dev/null 2>&1 || true
+          if ! echo "$MACOS_CERTIFICATE" | base64 --decode > "$CERT_PATH" 2>/dev/null; then
+            echo "$MACOS_CERTIFICATE" | base64 -d > "$CERT_PATH"
+          fi
+          security create-keychain -p "$MACOS_CERT_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings "$KEYCHAIN"
+          security unlock-keychain -p "$MACOS_CERT_PASSWORD" "$KEYCHAIN"
+          security import "$CERT_PATH" -k "$KEYCHAIN_PATH" -P "$MACOS_CERT_PASSWORD" -A
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $(security list-keychains -d user | sed 's/"//g')
+          security default-keychain -s "$KEYCHAIN"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$MACOS_CERT_PASSWORD" "$KEYCHAIN_PATH"
+          rm "$CERT_PATH"
+          identity=$(security find-identity -v -p codesigning "$KEYCHAIN" | head -n 1 | sed -E 's/^.*"(.+)"$/\1/')
+          if [ -z "$identity" ]; then
+            echo "No signing identity found in keychain" >&2
+            exit 1
+          fi
+          echo "CODESIGN_IDENTITY=$identity" >> "$GITHUB_ENV"
+          echo "SIGNING_KEYCHAIN=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
 
       - name: Build Backend for ${{ matrix.arch }}
         env:

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -1,5 +1,5 @@
 import type {ForgeConfig} from '@electron-forge/shared-types';
-import {MakerZIP} from '@electron-forge/maker-zip';
+import MakerZipFixed from './forge/maker-zip-fixed';
 import {MakerWix} from '@electron-forge/maker-wix';
 import {MakerSquirrel} from '@electron-forge/maker-squirrel';
 import {MakerDMG} from '@electron-forge/maker-dmg';
@@ -64,7 +64,7 @@ const config: ForgeConfig = {
     packagerConfig,
     rebuildConfig: {},
     makers: [
-        new MakerZIP({}),
+        new MakerZipFixed({}),
         new MakerSquirrel({
             name: 'Prizrak-Box',
             authors: ['legiz-ru'],

--- a/forge/maker-zip-fixed.ts
+++ b/forge/maker-zip-fixed.ts
@@ -1,0 +1,119 @@
+import path from 'node:path';
+import {execFile} from 'node:child_process';
+import {promisify} from 'node:util';
+import type {ForgeConfigMakerOptions} from '@electron-forge/shared-types';
+import {MakerBase} from '@electron-forge/maker-base';
+import fsExtra from 'fs-extra';
+import got from 'got';
+
+const execFileAsync = promisify(execFile);
+
+const quoteForPowershell = (value: string): string => `"${value.replace(/"/g, '""')}"`;
+
+async function createZipArchive(inputPath: string, outputPath: string, platform: NodeJS.Platform): Promise<void> {
+    if (platform === 'win32') {
+        const args = [
+            '-nologo',
+            '-noprofile',
+            '-command',
+            '& { param([String]$src, [String]$dest); Add-Type -A "System.IO.Compression.FileSystem"; ' +
+                'if (Test-Path -LiteralPath $dest) { Remove-Item -LiteralPath $dest -Force; } ' +
+                '[IO.Compression.ZipFile]::CreateFromDirectory($src, $dest); if ($?) { exit 0 } else { exit 1 } }',
+            '-src',
+            quoteForPowershell(inputPath),
+            '-dest',
+            quoteForPowershell(outputPath),
+        ];
+
+        await execFileAsync('powershell.exe', args, {
+            cwd: path.dirname(inputPath),
+            maxBuffer: Infinity,
+        });
+        return;
+    }
+
+    const parentDirectory = path.dirname(inputPath);
+    const entryName = path.basename(inputPath);
+    await execFileAsync('zip', ['-r', '-y', outputPath, entryName], {
+        cwd: parentDirectory,
+        maxBuffer: Infinity,
+    });
+}
+
+type MakerZipConfig = ForgeConfigMakerOptions['zip'];
+
+type MakeParams = Parameters<MakerBase<MakerZipConfig>['make']>[0];
+
+type ReleaseManifest = {
+    currentRelease: string;
+    releases: Array<{
+        version: string;
+        updateTo: {
+            name: string;
+            version: string;
+            pub_date: string;
+            url: string;
+            notes: string;
+        };
+    }>;
+};
+
+export default class MakerZipFixed extends MakerBase<MakerZipConfig> {
+    name = 'zip';
+
+    defaultPlatforms = ['darwin', 'mas', 'win32', 'linux'] as const;
+
+    isSupportedOnCurrentPlatform(): boolean {
+        return true;
+    }
+
+    async make({dir, makeDir, appName, packageJSON, targetArch, targetPlatform}: MakeParams): Promise<string[]> {
+        const zipDir = ['darwin', 'mas'].includes(targetPlatform) ? path.resolve(dir, `${appName}.app`) : dir;
+        const zipName = `${path.basename(dir)}-${packageJSON.version}.zip`;
+        const zipPath = path.resolve(makeDir, 'zip', targetPlatform, targetArch, zipName);
+
+        await this.ensureFile(zipPath);
+        await createZipArchive(zipDir, zipPath, process.platform);
+
+        if (targetPlatform === 'darwin' && this.config?.macUpdateManifestBaseUrl) {
+            const manifestUrl = new URL(this.config.macUpdateManifestBaseUrl);
+            manifestUrl.pathname += '/RELEASES.json';
+
+            const response = await got.get(manifestUrl.toString(), {
+                throwHttpErrors: false,
+            });
+
+            let manifest: ReleaseManifest = {
+                currentRelease: '',
+                releases: [],
+            };
+
+            if (response.statusCode === 200) {
+                manifest = JSON.parse(response.body) as ReleaseManifest;
+            }
+
+            const updateUrl = new URL(this.config.macUpdateManifestBaseUrl);
+            updateUrl.pathname += `/${zipName}`;
+
+            manifest.releases = (manifest.releases || []).filter((release) => release.version !== packageJSON.version);
+            manifest.currentRelease = packageJSON.version;
+            manifest.releases.push({
+                version: packageJSON.version,
+                updateTo: {
+                    name: `${appName} v${packageJSON.version}`,
+                    version: packageJSON.version,
+                    pub_date: new Date().toISOString(),
+                    url: updateUrl.toString(),
+                    notes: this.config.macUpdateReleaseNotes || '',
+                },
+            });
+
+            const releasesPath = path.resolve(makeDir, 'zip', targetPlatform, targetArch, 'RELEASES.json');
+            await this.ensureFile(releasesPath);
+            await fsExtra.writeJson(releasesPath, manifest);
+            return [zipPath, releasesPath];
+        }
+
+        return [zipPath];
+    }
+}


### PR DESCRIPTION
## Summary
- remove the postinstall patch mechanism and delete the cross-zip patch
- add a custom MakerZipFixed that packages Windows builds without deprecated fs.rmdir calls and keeps macOS manifest support
- wire the forge configuration to use the new maker implementation

## Testing
- npm run lint *(fails: pre-existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68fa0970f5e8832ca64cf54135c9ef21