### PR TITLE
Fix incorrect URL for ru-app-list.yaml ruleset

### DIFF
--- a/src-go/internal/em/Template_0.yaml
+++ b/src-go/internal/em/Template_0.yaml
@@ -135,7 +135,7 @@ rule-providers:
     type: http
     behavior: classical
     format: yaml
-    url: https://github.com/legiz-ru/mihomo-rule-sets/blob/main/other/ru-app-list.yaml
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/other/ru-app-list.yaml
     path: ./rule-sets/ru-app-list.yaml
     interval: 86400
   games-direct:

--- a/src-go/internal/em/Template_2.yaml
+++ b/src-go/internal/em/Template_2.yaml
@@ -497,7 +497,7 @@ rule-providers:
     type: http
     behavior: classical
     format: yaml
-    url: https://github.com/legiz-ru/mihomo-rule-sets/blob/main/other/ru-app-list.yaml
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/other/ru-app-list.yaml
     path: ./rule-sets/ru-apps.yaml
     interval: 86400
   ru-inside:


### PR DESCRIPTION
These rules does not work. The current URL uses `/blob/` and returns an HTML page instead of the raw YAML file, so the ruleset fails to load.