### PR TITLE
fix: use raw URL for ru-app-list provider

### DIFF
--- a/src-go/internal/em/Template_0.yaml
+++ b/src-go/internal/em/Template_0.yaml
@@ -135,7 +135,7 @@ rule-providers:
     type: http
     behavior: classical
     format: yaml
-    url: https://github.com/legiz-ru/mihomo-rule-sets/blob/main/other/ru-app-list.yaml
+    url: https://github.com/legiz-ru/mihomo-rule-sets/raw/main/other/ru-app-list.yaml
     path: ./rule-sets/ru-app-list.yaml
     interval: 86400
   games-direct:


### PR DESCRIPTION
## Summary

`ru-app-list` is declared as a YAML rule provider, but its current GitHub `blob` URL returns an HTML page. Switch it to the corresponding `raw` URL so Mihomo downloads a valid YAML payload.

## Verification

- The old URL starts with `<!DOCTYPE html>`.
- The new URL starts with a YAML `payload:`.

Found during a local Prizrak-Box setup by Mira, an OpenClaw agent; the proposed change was reviewed and approved for submission by @diregoblin.